### PR TITLE
problem: users need examples of paginating the transfer endpoints

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -11,7 +11,7 @@ templater = jinja
 # See https://docs.sqlfluff.com/en/stable/configuration.html#enabling-and-disabling-rules
 # AM04 (ambiguous.column_count) and ST06 (structure.column_order) are
 # two of the more controversial rules included to illustrate usage.
-exclude_rules = ambiguous.column_count, structure.column_order, LT01, LT08, RF02, LT09, LT02, AL06
+exclude_rules = ambiguous.column_count, structure.column_order, LT01, LT08, RF02, LT09, LT02, AL06, ST05
 
 # The standard max_line_length is 80 in line with the convention of
 # other tools and several style guides. Many projects however prefer

--- a/doc/examples/private/deposit_withdrawals.sql
+++ b/doc/examples/private/deposit_withdrawals.sql
@@ -1,0 +1,85 @@
+------------------------------------------------------------------------
+-- Examples of how to call to place orders using generate_series
+------------------------------------------------------------------------
+create extension if not exists pg_deribit cascade; --noqa:PRS
+
+select deribit.set_client_auth('<CLIENT_ID>', '<CLIENT_SECRET>');
+select deribit.enable_test_net();
+
+------------------------------------------------------------
+-- Example of retrieving all deposits since the beginning
+------------------------------------------------------------
+with currencies as (
+    select unnest(enum_range(null::deribit.private_get_deposits_request_currency)) as code
+),
+paginated_deposits as (
+    select
+        d.*
+    from currencies as c
+    inner join lateral (
+        with recursive recursive_deposits as (
+            select
+                *,
+                0 as current_offset
+            from deribit.private_get_deposits(
+                currency := c.code,
+                "offset" := 0,
+                count := 1000
+            )
+            union all
+            select
+                d.*,
+                rd.current_offset + 1 as current_offset
+            from recursive_deposits as rd
+            inner join lateral deribit.private_get_deposits(
+                currency := c.code,
+                "offset" := rd.current_offset + 1000,
+                count := 1000
+            ) as d on true
+            where array_length(d.data, 1) is not null
+        )
+        select *
+        from recursive_deposits
+    ) as d on true
+)
+select (unnest(data)).*
+from paginated_deposits;
+
+------------------------------------------------------------
+-- Example of retrieving all withdrawals since the beginning
+------------------------------------------------------------
+with currencies as (
+    select unnest(enum_range(null::deribit.private_get_withdrawals_request_currency)) as code
+),
+withdrawals as (
+    select
+        d.*
+    from currencies as c
+    inner join lateral (
+        with recursive recursive_withdrawals as (
+            select
+                *,
+                0 as current_offset
+            from deribit.private_get_withdrawals(
+                currency := c.code,
+                "offset" := 0,
+                count := 1000
+            )
+            union all
+            select
+                d.*,
+                rd.current_offset + 1 as current_offset
+            from recursive_withdrawals as rd
+            inner join lateral deribit.private_get_withdrawals(
+                currency := c.code,
+                "offset" := rd.current_offset + 1000,
+                count := 1000
+            ) d on true
+            where array_length(d.data, 1) is not null
+        )
+        select *
+        from recursive_withdrawals
+    ) as d on true
+)
+select (unnest(data)).*
+from withdrawals;

--- a/doc/examples/private/transfers.sql
+++ b/doc/examples/private/transfers.sql
@@ -1,0 +1,46 @@
+------------------------------------------------------------------------
+-- Examples of how to call to place orders using generate_series
+------------------------------------------------------------------------
+create extension if not exists pg_deribit cascade; --noqa:PRS
+
+select deribit.set_client_auth('<CLIENT_ID>', '<CLIENT_SECRET>');
+select deribit.enable_test_net();
+
+------------------------------------------------------------
+-- Example of retrieving all deposits since the beginning
+------------------------------------------------------------
+with currencies as (
+    select unnest(enum_range(null::deribit.private_get_transfers_request_currency)) as code
+),
+paginated_transfer as (
+    select
+        d.*
+    from currencies as c
+    inner join lateral (
+        with recursive recursive_transfers as (
+            select
+                *,
+                0 as current_offset
+            from deribit.private_get_transfers(
+                currency := c.code,
+                "offset" := 0,
+                count := 1000
+            )
+            union all
+            select
+                d.*,
+                rd.current_offset + 1 as current_offset
+            from recursive_transfers as rd
+            inner join lateral deribit.private_get_transfers(
+                currency := c.code,
+                "offset" := rd.current_offset + 1000,
+                count := 1000
+            ) as d on true
+            where array_length(d.data, 1) is not null
+        )
+        select *
+        from recursive_transfers
+    ) as d on true
+)
+select (unnest(data)).*
+from paginated_transfer;


### PR DESCRIPTION
solution: add advanced example of how to paginate the transfer endpoints using recursive cte within subqueries.