### PR TITLE
Update Deribit API endpoints

### DIFF
--- a/codegen/deribit.html
+++ b/codegen/deribit.html
@@ -943,6 +943,9 @@
                     <a href="#block_trade_confirmations" class="toc-h2 toc-link" data-title="block_trade_confirmations">block_trade_confirmations</a>
                   </li>
                   <li>
+                    <a href="#block_trade_confirmations-currency" class="toc-h2 toc-link" data-title="block_trade_confirmations.{currency}">block_trade_confirmations.{currency}</a>
+                  </li>
+                  <li>
                     <a href="#book-instrument_name-group-depth-interval" class="toc-h2 toc-link" data-title="book.{instrument_name}.{group}.{depth}.{interval}">book.{instrument_name}.{group}.{depth}.{interval}</a>
                   </li>
                   <li>
@@ -1517,10 +1520,9 @@ When that happens the client is required to resend a request with additional par
 <ul>
 <li><code>security_keys</code> -  a list of security keys that can be used for authentication. Fields in Security Key object are:
 <ul>
-  <li><code>type</code> - type of security key: <code>tfa</code> for TOTP Two Factor Authentication, <code>u2f</code> for authentication with Yubikey</li>
+  <li><code>type</code> - type of security key: <code>tfa</code> for TOTP Two Factor Authentication</li>
   <li><code>name</code> - name of security key</li>
-  <li><code>credential_id</code> - optional filed for U2F keys only</li>
-</ul></li>
+  </ul></li>
 <li><code>rp_id</code> - relying party identifier (need to be used with WebAuthn)</li>
 <li><code>challenge</code> - this string needs to be resend, it is valid for 1 minute</li>
 </ul></p>
@@ -1556,9 +1558,7 @@ When that happens the client is required to resend a request with additional par
         </span><span class="nl">"challenge"</span><span class="p">:</span><span class="w"> </span><span class="s2">"+Di4SKN9VykrSoHlZO2KF3LEyEZF4ih9CZXVuudQiKQ="</span><span class="w">
     </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
-</span></code></pre></div><h3 id='u2f-authorization'>U2F authorization</h3>
-<p>For details of U2F authorization ask our staff.</p>
-<h3 id='errors'>Errors:</h3>
+</span></code></pre></div><h3 id='errors'>Errors:</h3>
 <p>When there is an error related to the Security Key authorization, a response with the error <code>security_key_authorization_error</code> (code: 13668) is returned.  It will have a <code>data.reason</code> field that possible values are:
 <ul>
 <li><code>tfa_code_not_matched</code> - provided TFA code was invalid</li>
@@ -4403,7 +4403,8 @@ in what form.</p>
 </span><span class="p">}</span><span class="w">
 
 </span></code></pre></div>
-<p>Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).</p>
+<p>Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
+<strong>Note</strong> - For real-time updates, we recommend using the WebSocket subscription to <code>ticker.{instrument_name}.{interval}</code> instead of polling this endpoint.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fpublic%2Fget_book_summary_by_currency" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 <h3 id='parameters-21'>Parameters</h3>
@@ -6608,7 +6609,8 @@ in what form.</p>
 </span><span class="p">}</span><span class="w">
 
 </span></code></pre></div>
-<p>Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.</p>
+<p>Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.
+<strong>Note - This endpoint has distinct API rate limiting requirements:</strong> 1 request per 10 seconds, with a burst of 5. To avoid rate limits, we recommend using either the REST requests for server-cached data or the WebSocket subscription to <a href="https://docs.deribit.com/#instrument-state-kind-currency">instrument_state.{kind}.{currency}</a> for real-time updates. For more information, see <a href="https://support.deribit.com/hc/en-us/articles/25944617523357-Rate-Limits">Rate Limits</a>.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fpublic%2Fget_instruments" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 <h3 id='parameters-35'>Parameters</h3>
@@ -10319,11 +10321,11 @@ in what form.</p>
 <td><p>Specifies how long the order remains in effect. Default <code>&quot;good_til_cancelled&quot;</code></p> <ul> <li><code>&quot;good_til_cancelled&quot;</code> - unfilled order remains in order book until cancelled</li> <li><code>&quot;good_til_day&quot;</code> - unfilled order remains in order book till the end of the trading session</li> <li><code>&quot;fill_or_kill&quot;</code> - execute a transaction immediately and completely or not at all</li> <li><code>&quot;immediate_or_cancel&quot;</code> - execute a transaction immediately, and any portion of the order that cannot be immediately filled is cancelled</li> </ul></td>
 </tr>
 <tr>
-<td>max_show</td>
+<td>display_amount</td>
 <td>false</td>
 <td>number</td>
 <td></td>
-<td>Maximum amount within an order to be shown to other customers, <code>0</code> for invisible order</td>
+<td>Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.</td>
 </tr>
 <tr>
 <td>post_only</td>
@@ -10548,6 +10550,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -10703,6 +10710,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -10751,11 +10763,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -11136,11 +11143,11 @@ in what form.</p>
 <td><p>Specifies how long the order remains in effect. Default <code>&quot;good_til_cancelled&quot;</code></p> <ul> <li><code>&quot;good_til_cancelled&quot;</code> - unfilled order remains in order book until cancelled</li> <li><code>&quot;good_til_day&quot;</code> - unfilled order remains in order book till the end of the trading session</li> <li><code>&quot;fill_or_kill&quot;</code> - execute a transaction immediately and completely or not at all</li> <li><code>&quot;immediate_or_cancel&quot;</code> - execute a transaction immediately, and any portion of the order that cannot be immediately filled is cancelled</li> </ul></td>
 </tr>
 <tr>
-<td>max_show</td>
+<td>display_amount</td>
 <td>false</td>
 <td>number</td>
 <td></td>
-<td>Maximum amount within an order to be shown to other customers, <code>0</code> for invisible order</td>
+<td>Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.</td>
 </tr>
 <tr>
 <td>post_only</td>
@@ -11365,6 +11372,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -11520,6 +11532,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -11568,11 +11585,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -11984,6 +11996,13 @@ in what form.</p>
 <td></td>
 <td>Timestamp, when provided server will start processing request in Matching Engine only before given timestamp, in other cases <code>timed_out</code> error will be responded. Remember that the given timestamp should be consistent with the server&#39;s time, use <a href='#public-get_time'>/public/time</a> method to obtain current server time.</td>
 </tr>
+<tr>
+<td>display_amount</td>
+<td>false</td>
+<td>number</td>
+<td></td>
+<td>Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.</td>
+</tr>
 </tbody></table>
 <h3 id='response-53'>Response</h3>
 <table><thead>
@@ -12037,6 +12056,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -12194,6 +12218,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -12242,11 +12271,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -12713,6 +12737,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -12868,6 +12897,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -12916,11 +12950,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -13295,6 +13324,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -13450,6 +13484,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -13498,11 +13537,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -14712,6 +14746,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -14867,6 +14906,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -14915,11 +14959,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -15788,6 +15827,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -15943,6 +15987,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -15991,11 +16040,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -16195,6 +16239,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -16350,6 +16399,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -16398,11 +16452,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -16595,6 +16644,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -16750,6 +16804,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -16798,11 +16857,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -16997,6 +17051,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -17152,6 +17211,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -17200,11 +17264,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -17450,6 +17509,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -17605,6 +17669,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -17653,11 +17722,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -17894,6 +17958,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -18049,6 +18118,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -18097,11 +18171,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -18435,6 +18504,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -18590,6 +18664,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -18638,11 +18717,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -18837,6 +18911,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -18992,6 +19071,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -19040,11 +19124,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -21733,6 +21812,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -21888,6 +21972,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -21936,11 +22025,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -26336,7 +26420,7 @@ in what form.</p>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;signature</td>
 <td>string</td>
-<td>Signature of block trade<br>It is valid only for 5 minutes “around” given timestamp</td>
+<td>Signature of block trade<br>It is valid only for 5 minutes around given timestamp</br></td>
 </tr>
 </tbody></table>
 <h1 id='block-rfq'>Block RFQ</h1><h2 id='public-get_block_rfq_trades'>/public/get_block_rfq_trades</h2><div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> GET <span class="s2">"https://test.deribit.com/api/v2/public/get_block_rfq_trades?currency=BTC"</span> <span class="se">\</span>
@@ -26670,7 +26754,7 @@ in what form.</p>
 <td>Continuation token for pagination. <code>NULL</code> when no continuation. Consists of <code>timestamp</code> and <code>block_rfq_id</code>.</td>
 </tr>
 </tbody></table>
-<h2 id='private-add_block_rfq_quote'>/private/add_block_rfq_quote</h2><div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> GET <span class="s2">"https://test.deribit.com/api/v2/private/add_block_rfq_quote?amount=10000&amp;block_rfq_id=3&amp;direction=buy&amp;execution_instruction=any_part_of&amp;hedge=%7B%22price%22%3A70000%2C%22instrument_name%22%3A%22BTC-PERPETUAL%22%2C%22direction%22%3A%22buy%22%2C%22amount%22%3A10%7D&amp;label=example_quote&amp;legs=%5B%7B%22ratio%22%3A%221%22%2C%22price%22%3A69600%2C%22instrument_name%22%3A%22BTC-15NOV24%22%2C%22direction%22%3A%22buy%22%7D%5D"</span> <span class="se">\</span>
+<h2 id='private-add_block_rfq_quote'>/private/add_block_rfq_quote</h2><div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> GET <span class="s2">"https://test.deribit.com/api/v2/private/add_block_rfq_quote?amount=10000&amp;block_rfq_id=3&amp;direction=buy&amp;execution_instruction=any_part_of&amp;expires_at=1745312540321&amp;hedge=%7B%22price%22%3A70000%2C%22instrument_name%22%3A%22BTC-PERPETUAL%22%2C%22direction%22%3A%22buy%22%2C%22amount%22%3A10%7D&amp;label=example_quote&amp;legs=%5B%7B%22ratio%22%3A%221%22%2C%22price%22%3A69600%2C%22instrument_name%22%3A%22BTC-15NOV24%22%2C%22direction%22%3A%22buy%22%7D%5D"</span> <span class="se">\</span>
 <span class="nt">-H</span> <span class="s2">"Authorization: Bearer 1529453804065.h2QrBgvn.oS36pCOmuK9EX7954lzCSkUioEtTMg7F5ShToM0ZfYlqU05OquXkQIe2_DDEkPhzmoPp1fBp0ycXShR_0jf-SMSXEdVqxLRWuOw-_StG5BMjToiAl27CbHY4P92MPhlMblTOtTImE81-5dFdyDVydpBwmlfKM3OSQ39kulP9bbfw-2jhyegOL0AgqJTY_tj554oHCQFTbq0A0ZWukukmxL2yu6iy34XdzaJB26Igy-3UxGBMwFu53EhjKBweh7xyP2nDm57-wybndJMtSyTGDXH3vjBVclo1iup5yRP"</span> <span class="se">\</span>
 <span class="nt">-H</span> <span class="s2">"Content-Type: application/json"</span>
 </code></pre></div><div class="highlight"><pre class="highlight javascript tab-javascript"><code><span class="kd">var</span> <span class="nx">msg</span> <span class="o">=</span> 
@@ -26695,7 +26779,8 @@ in what form.</p>
       <span class="dl">"</span><span class="s2">price</span><span class="dl">"</span> <span class="p">:</span> <span class="mi">70000</span><span class="p">,</span>
       <span class="dl">"</span><span class="s2">instrument_name</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2">BTC-PERPETUAL</span><span class="dl">"</span>
     <span class="p">},</span>
-    <span class="dl">"</span><span class="s2">execution_instruction</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2">any_part_of</span><span class="dl">"</span>
+    <span class="dl">"</span><span class="s2">execution_instruction</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2">any_part_of</span><span class="dl">"</span><span class="p">,</span>
+    <span class="dl">"</span><span class="s2">expires_at</span><span class="dl">"</span> <span class="p">:</span> <span class="mi">1745312540321</span>
   <span class="p">},</span>
   <span class="dl">"</span><span class="s2">jsonrpc</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2">2.0</span><span class="dl">"</span><span class="p">,</span>
   <span class="dl">"</span><span class="s2">id</span><span class="dl">"</span> <span class="p">:</span> <span class="mi">1</span>
@@ -26738,7 +26823,8 @@ in what form.</p>
       <span class="s">"price"</span> <span class="p">:</span> <span class="mi">70000</span><span class="p">,</span>
       <span class="s">"instrument_name"</span> <span class="p">:</span> <span class="s">"BTC-PERPETUAL"</span>
     <span class="p">},</span>
-    <span class="s">"execution_instruction"</span> <span class="p">:</span> <span class="s">"any_part_of"</span>
+    <span class="s">"execution_instruction"</span> <span class="p">:</span> <span class="s">"any_part_of"</span><span class="p">,</span>
+    <span class="s">"expires_at"</span> <span class="p">:</span> <span class="mi">1745312540321</span>
   <span class="p">},</span>
   <span class="s">"jsonrpc"</span> <span class="p">:</span> <span class="s">"2.0"</span><span class="p">,</span>
   <span class="s">"id"</span> <span class="p">:</span> <span class="mi">1</span>
@@ -26922,6 +27008,13 @@ in what form.</p>
 <td>number</td>
 <td></td>
 <td>Aggregated price used for quoting future spreads.</td>
+</tr>
+<tr>
+<td>expires_at</td>
+<td>false</td>
+<td>integer</td>
+<td></td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch)</td>
 </tr>
 </tbody></table>
 <h3 id='response-104'>Response</h3>
@@ -27344,6 +27437,11 @@ in what form.</p>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
 <td>integer</td>
 <td>Timestamp of the last update of the quote (milliseconds since the UNIX epoch)</td>
@@ -27372,6 +27470,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;execution_instruction</td>
 <td>string</td>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
@@ -28078,6 +28181,11 @@ in what form.</p>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
 <td>integer</td>
 <td>Timestamp of the last update of the quote (milliseconds since the UNIX epoch)</td>
@@ -28106,6 +28214,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;execution_instruction</td>
 <td>string</td>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
@@ -29386,6 +29499,11 @@ in what form.</p>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
 <td>integer</td>
 <td>Timestamp of the last update of the quote (milliseconds since the UNIX epoch)</td>
@@ -29414,6 +29532,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;execution_instruction</td>
 <td>string</td>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
@@ -30235,6 +30358,13 @@ in what form.</p>
 <td>DID of beneficiary VASP</td>
 </tr>
 <tr>
+<td>beneficiary_vasp_website</td>
+<td>false</td>
+<td>string</td>
+<td></td>
+<td>Website of the beneficiary VASP. Required if the address book entry is associated with a VASP that is not included in the list of known VASPs</td>
+</tr>
+<tr>
 <td>beneficiary_first_name</td>
 <td>false</td>
 <td>string</td>
@@ -30275,6 +30405,13 @@ in what form.</p>
 <td>boolean</td>
 <td></td>
 <td>The user confirms that he provided address belongs to him and he has access to it via an un-hosted wallet software</td>
+</tr>
+<tr>
+<td>extra_currencies</td>
+<td>false</td>
+<td>array</td>
+<td></td>
+<td>The user can pass a list of currencies to add the address for. It is currently available ONLY for ERC20 currencies. Without passing this paramater for an ERC20 currency, the address will be added to ALL of the ERC20 currencies.</td>
 </tr>
 </tbody></table>
 <h3 id='response-115'>Response</h3>
@@ -30339,6 +30476,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;beneficiary_vasp_name</td>
 <td>string</td>
 <td>Name of beneficiary VASP</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;beneficiary_vasp_website</td>
+<td>string</td>
+<td>Website of the beneficiary VASP</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;creation_timestamp</td>
@@ -31081,6 +31223,11 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;beneficiary_vasp_name</td>
 <td>string</td>
 <td>Name of beneficiary VASP</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;beneficiary_vasp_website</td>
+<td>string</td>
+<td>Website of the beneficiary VASP</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;creation_timestamp</td>
@@ -32975,6 +33122,13 @@ in what form.</p>
 <td>DID of beneficiary VASP</td>
 </tr>
 <tr>
+<td>beneficiary_vasp_website</td>
+<td>false</td>
+<td>string</td>
+<td></td>
+<td>Website of the beneficiary VASP. Required if the address book entry is associated with a VASP that is not included in the list of known VASPs</td>
+</tr>
+<tr>
 <td>beneficiary_first_name</td>
 <td>false</td>
 <td>string</td>
@@ -34342,7 +34496,7 @@ in what form.</p>
     </span><span class="nl">"jsonrpc"</span><span class="p">:</span><span class="w"> </span><span class="s2">"2.0"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">5414</span><span class="p">,</span><span class="w">
     </span><span class="nl">"result"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-        </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="77020412052836363637121a161e1b5914181a">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="5c292f392e031d1d1d1c39313d3530723f3331">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
         </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">13</span><span class="p">,</span><span class="w">
         </span><span class="nl">"is_password"</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span><span class="w">
         </span><span class="nl">"login_enabled"</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span><span class="w">
@@ -35471,7 +35625,7 @@ in what form.</p>
   </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">2515</span><span class="p">,</span><span class="w">
   </span><span class="nl">"result"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
     </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">10</span><span class="p">,</span><span class="w">
-    </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="a8dddbcddae8cdd0c9c5d8c4cd86cbc7c5">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
+    </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="b6c3c5d3c4f6d3ced7dbc6dad398d5d9db">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"system_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"username"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"block_rfq_self_match_prevention"</span><span class="p">:</span><span class="kc">true</span><span class="p">,</span><span class="w">
@@ -35543,7 +35697,45 @@ in what form.</p>
         </span><span class="nl">"spot_reserve"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
         </span><span class="nl">"delta_total"</span><span class="p">:</span><span class="w"> </span><span class="mf">31.602958</span><span class="p">,</span><span class="w">
         </span><span class="nl">"options_gamma"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00001</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"session_rpl"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.03258105</span><span class="w">
+        </span><span class="nl">"session_rpl"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.03258105</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"fees"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00035</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.0001</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.3</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"perpetual"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"relative"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"option"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00035</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.0001</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.3</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"future"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+          </span><span class="p">}</span><span class="w">
+        </span><span class="p">]</span><span class="w">
       </span><span class="p">},</span><span class="w">
 
       </span><span class="p">{</span><span class="w">
@@ -35603,7 +35795,45 @@ in what form.</p>
         </span><span class="nl">"total_pl"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
         </span><span class="nl">"session_rpl"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
         </span><span class="nl">"options_value"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
-        </span><span class="nl">"margin_balance"</span><span class="p">:</span><span class="w"> </span><span class="mi">100</span><span class="w">
+        </span><span class="nl">"margin_balance"</span><span class="p">:</span><span class="w"> </span><span class="mi">100</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"fees"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00025</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.00005</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.2</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"perpetual"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"eth_usd"</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"relative"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.5</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.5</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.5</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"option"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"eth_usd"</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+              </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+                </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00025</span><span class="p">,</span><span class="w">
+                </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.00005</span><span class="w">
+              </span><span class="p">},</span><span class="w">
+              </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.2</span><span class="w">
+            </span><span class="p">},</span><span class="w">
+            </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"future"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"eth_usd"</span><span class="w">
+          </span><span class="p">}</span><span class="w">
+        </span><span class="p">]</span><span class="w">
       </span><span class="p">}</span><span class="w">
     </span><span class="p">]</span><span class="w">
   </span><span class="p">}</span><span class="w">
@@ -35788,32 +36018,52 @@ in what form.</p>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;fees</td>
 <td>array of <em>object</em></td>
-<td>User fees in case of any discounts (available when parameter <code>extended</code> = <code>true</code> and user has any discounts)</td>
+<td>List of fee objects for all currency pairs and instrument types related to the currency (available when parameter <code>extended</code> = <code>true</code> and user has any discounts)</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;currency</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;index_name</td>
 <td>string</td>
-<td>The currency the fee applies to</td>
+<td>The currency pair this fee applies to</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;fee_type</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;kind</td>
 <td>string</td>
-<td>Fee type - <code>relative</code> if fee is calculated as a fraction of base instrument fee, <code>fixed</code> if fee is calculated solely using user fee</td>
+<td>Instrument type (e.g., future, perpetual, option)</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;instrument_type</td>
-<td>string</td>
-<td>Type of the instruments the fee applies to - <code>future</code> for future instruments (excluding perpetual), <code>perpetual</code> for future perpetual instruments, <code>option</code> for options</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;value</td>
+<td><em>object</em></td>
+<td></td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;maker_fee</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;block_trade</td>
 <td>number</td>
-<td>User fee as a maker</td>
+<td>Block trade fee (if applicable)</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;taker_fee</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;default</td>
+<td><em>object</em></td>
+<td></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;maker</td>
 <td>number</td>
-<td>User fee as a taker</td>
+<td>Maker fee</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;taker</td>
+<td>number</td>
+<td>Taker fee</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;type</td>
+<td>string</td>
+<td>Fee calculation type (e.g., fixed, relative)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;settlement</td>
+<td>number</td>
+<td>Settlement fee</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;additional_reserve</td>
@@ -36062,7 +36312,7 @@ in what form.</p>
       </span><span class="nl">"btc_usd"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.1009872222854525</span><span class="w">
     </span><span class="p">},</span><span class="w">
     </span><span class="nl">"session_upl"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.05271555</span><span class="p">,</span><span class="w">
-    </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="bfcaccdacdffdac7ded2cfd3da91dcd0d2">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
+    </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="b2c7c1d7c0f2d7cad3dfc2ded79cd1dddf">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"system_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"username"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user"</span><span class="p">,</span><span class="w">
     </span><span class="nl">"interuser_transfers_enabled"</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span><span class="w">
@@ -36127,7 +36377,45 @@ in what form.</p>
     </span><span class="nl">"spot_reserve"</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span><span class="w">
     </span><span class="nl">"delta_total"</span><span class="p">:</span><span class="w"> </span><span class="mf">31.602958</span><span class="p">,</span><span class="w">
     </span><span class="nl">"options_gamma"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00001</span><span class="p">,</span><span class="w">
-    </span><span class="nl">"session_rpl"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.03258105</span><span class="w">
+    </span><span class="nl">"session_rpl"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.03258105</span><span class="p">,</span><span class="w">
+    </span><span class="nl">"fees"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+      </span><span class="p">{</span><span class="w">
+        </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+          </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00035</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.0001</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.3</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"perpetual"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+      </span><span class="p">},</span><span class="w">
+      </span><span class="p">{</span><span class="w">
+        </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+          </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"relative"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.625</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"option"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+      </span><span class="p">},</span><span class="w">
+      </span><span class="p">{</span><span class="w">
+        </span><span class="nl">"value"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+          </span><span class="nl">"default"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+            </span><span class="nl">"type"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fixed"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"taker"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.00035</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"maker"</span><span class="p">:</span><span class="w"> </span><span class="mf">-0.0001</span><span class="w">
+          </span><span class="p">},</span><span class="w">
+          </span><span class="nl">"block_trade"</span><span class="p">:</span><span class="w"> </span><span class="mf">0.3</span><span class="w">
+        </span><span class="p">},</span><span class="w">
+        </span><span class="nl">"kind"</span><span class="p">:</span><span class="w"> </span><span class="s2">"future"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"index_name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"btc_usd"</span><span class="w">
+      </span><span class="p">}</span><span class="w">
+    </span><span class="p">]</span><span class="w">
   </span><span class="p">}</span><span class="w">
 </span><span class="p">}</span><span class="w">
 
@@ -36262,32 +36550,52 @@ in what form.</p>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;fees</td>
 <td>array of <em>object</em></td>
-<td>User fees in case of any discounts (available when parameter <code>extended</code> = <code>true</code> and user has any discounts)</td>
+<td>List of fee objects for all currency pairs and instrument types related to the currency (available when parameter <code>extended</code> = <code>true</code> and user has any discounts)</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;currency</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;index_name</td>
 <td>string</td>
-<td>The currency the fee applies to</td>
+<td>The currency pair this fee applies to</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;fee_type</td>
-<td>string</td>
-<td>Fee type - <code>relative</code> if fee is calculated as a fraction of base instrument fee, <code>fixed</code> if fee is calculated solely using user fee</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;instrument_type</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;kind</td>
 <td>string</td>
 <td>Type of the instruments the fee applies to - <code>future</code> for future instruments (excluding perpetual), <code>perpetual</code> for future perpetual instruments, <code>option</code> for options</td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;maker_fee</td>
-<td>number</td>
-<td>User fee as a maker</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;value</td>
+<td><em>object</em></td>
+<td></td>
 </tr>
 <tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;taker_fee</td>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;block_trade</td>
 <td>number</td>
-<td>User fee as a taker</td>
+<td>Block trade fee (if applicable)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;default</td>
+<td><em>object</em></td>
+<td></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;maker</td>
+<td>number</td>
+<td>Maker fee</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;taker</td>
+<td>number</td>
+<td>Taker fee</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;type</td>
+<td>string</td>
+<td>Fee type - <code>relative</code> if fee is calculated as a fraction of base instrument fee, <code>fixed</code> if fee is calculated solely using user fee</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;settlement</td>
+<td>number</td>
+<td>Settlement fee</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;additional_reserve</td>
@@ -37461,7 +37769,7 @@ in what form.</p>
     </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">4947</span><span class="p">,</span><span class="w">
     </span><span class="nl">"result"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
         </span><span class="p">{</span><span class="w">
-            </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="394c4a5c4b66787878795c54585055175a5654">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="2b5e584e59746a6a6a6b4e464a424705484446">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
             </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">2</span><span class="p">,</span><span class="w">
             </span><span class="nl">"is_password"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span><span class="w">
             </span><span class="nl">"margin_model"</span><span class="p">:</span><span class="w"> </span><span class="s2">"segregated_sm"</span><span class="p">,</span><span class="w">
@@ -37500,7 +37808,7 @@ in what form.</p>
             </span><span class="nl">"username"</span><span class="p">:</span><span class="w"> </span><span class="s2">"user_1"</span><span class="w">
         </span><span class="p">},</span><span class="w">
         </span><span class="p">{</span><span class="w">
-            </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="4c393f293e130d0d0d0c2b212d2520622f2321">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
+            </span><span class="nl">"email"</span><span class="p">:</span><span class="w"> </span><span class="s2">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="f085839582afb1b1b1b0979d91999cde939f9d">[email&#160;protected]</a>"</span><span class="p">,</span><span class="w">
             </span><span class="nl">"id"</span><span class="p">:</span><span class="w"> </span><span class="mi">7</span><span class="p">,</span><span class="w">
             </span><span class="nl">"is_password"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span><span class="w">
             </span><span class="nl">"margin_model"</span><span class="p">:</span><span class="w"> </span><span class="s2">"cross_pm"</span><span class="p">,</span><span class="w">
@@ -37971,6 +38279,11 @@ in what form.</p>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
 <td>number</td>
 <td>Option price in USD (Only if <code>advanced=&quot;usd&quot;</code>)</td>
@@ -38126,6 +38439,11 @@ in what form.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -38174,11 +38492,6 @@ in what form.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -40257,7 +40570,7 @@ in what form.</p>
   <span class="dl">"</span><span class="s2">method</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2">private/set_email_for_subaccount</span><span class="dl">"</span><span class="p">,</span>
   <span class="dl">"</span><span class="s2">params</span><span class="dl">"</span> <span class="p">:</span> <span class="p">{</span>
     <span class="dl">"</span><span class="s2">sid</span><span class="dl">"</span> <span class="p">:</span> <span class="mi">7</span><span class="p">,</span>
-    <span class="dl">"</span><span class="s2">email</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="bcc9cfd9cee38de38dfcd9d1ddd5d092dfd3d1">[email&#160;protected]</a></span><span class="dl">"</span>
+    <span class="dl">"</span><span class="s2">email</span><span class="dl">"</span> <span class="p">:</span> <span class="dl">"</span><span class="s2"><a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="285d5b4d5a77197719684d45494144064b4745">[email&#160;protected]</a></span><span class="dl">"</span>
   <span class="p">}</span>
 <span class="p">};</span>
 <span class="kd">var</span> <span class="nx">ws</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">WebSocket</span><span class="p">(</span><span class="dl">'</span><span class="s1">wss://test.deribit.com/ws/api/v2</span><span class="dl">'</span><span class="p">);</span>
@@ -40283,7 +40596,7 @@ in what form.</p>
   <span class="s">"method"</span> <span class="p">:</span> <span class="s">"private/set_email_for_subaccount"</span><span class="p">,</span>
   <span class="s">"params"</span> <span class="p">:</span> <span class="p">{</span>
     <span class="s">"sid"</span> <span class="p">:</span> <span class="mi">7</span><span class="p">,</span>
-    <span class="s">"email"</span> <span class="p">:</span> <span class="s">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="493c3a2c3b16781678092c24282025672a2624">[email&#160;protected]</a>"</span>
+    <span class="s">"email"</span> <span class="p">:</span> <span class="s">"<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="c4b1b7a1b69bf59bf584a1a9a5ada8eaa7aba9">[email&#160;protected]</a>"</span>
   <span class="p">}</span>
 <span class="p">}</span>
 
@@ -41585,6 +41898,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
 <td>integer</td>
 <td>Timestamp of the last update of the quote (milliseconds since the UNIX epoch)</td>
@@ -41613,6 +41931,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;execution_instruction</td>
 <td>string</td>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
@@ -41939,6 +42262,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
 <td>integer</td>
 <td>Timestamp of the last update of the quote (milliseconds since the UNIX epoch)</td>
@@ -41967,6 +42295,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;execution_instruction</td>
 <td>string</td>
 <td><p>Execution instruction of the quote. Default - <code>any_part_of</code></p> <ul> <li><code>&quot;all_or_none (AON)&quot;</code> - The quote can only be filled entirely or not at all, ensuring that its amount matches the amount specified in the Block RFQ. Additionally, &#39;all_or_none&#39; quotes have priority over &#39;any_part_of&#39; quotes at the same price level.</li> <li><code>&quot;any_part_of (APO)&quot;</code> - The quote can be filled either partially or fully, with the filled amount potentially being less than the Block RFQ amount. </li> </ul></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;expires_at</td>
+<td>integer</td>
+<td>The timestamp when the quote expires (milliseconds since the Unix epoch), equal to the earliest expiry of placed quotes</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;last_update_timestamp</td>
@@ -42517,6 +42850,193 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Unique user identifier</td>
 </tr>
 </tbody></table>
+<h2 id='block_trade_confirmations-currency'>block_trade_confirmations.{currency}</h2>
+<blockquote>
+<p><em>Subscriptions are only available via websockets.</em></p>
+</blockquote>
+<div class="highlight"><pre class="highlight javascript tab-javascript"><code><span class="c1">// To subscribe to this channel:</span>
+<span class="kd">var</span> <span class="nx">msg</span> <span class="o">=</span> 
+    <span class="p">{</span><span class="dl">"</span><span class="s2">jsonrpc</span><span class="dl">"</span><span class="p">:</span> <span class="dl">"</span><span class="s2">2.0</span><span class="dl">"</span><span class="p">,</span>
+     <span class="dl">"</span><span class="s2">method</span><span class="dl">"</span><span class="p">:</span> <span class="dl">"</span><span class="s2">public/subscribe</span><span class="dl">"</span><span class="p">,</span>
+     <span class="dl">"</span><span class="s2">id</span><span class="dl">"</span><span class="p">:</span> <span class="mi">42</span><span class="p">,</span>
+     <span class="dl">"</span><span class="s2">params</span><span class="dl">"</span><span class="p">:</span> <span class="p">{</span>
+        <span class="dl">"</span><span class="s2">channels</span><span class="dl">"</span><span class="p">:</span> <span class="p">[</span><span class="dl">"</span><span class="s2">block_trade_confirmations.btc</span><span class="dl">"</span><span class="p">]}</span>
+    <span class="p">};</span>
+<span class="kd">var</span> <span class="nx">ws</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">WebSocket</span><span class="p">(</span><span class="dl">'</span><span class="s1">wss://test.deribit.com/ws/api/v2</span><span class="dl">'</span><span class="p">);</span>
+<span class="nx">ws</span><span class="p">.</span><span class="nx">onmessage</span> <span class="o">=</span> <span class="kd">function</span> <span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// do something with the notifications...</span>
+    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="dl">'</span><span class="s1">received from server : </span><span class="dl">'</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">data</span><span class="p">);</span>
+<span class="p">};</span>
+<span class="nx">ws</span><span class="p">.</span><span class="nx">onopen</span> <span class="o">=</span> <span class="kd">function</span> <span class="p">()</span> <span class="p">{</span>
+    <span class="nx">ws</span><span class="p">.</span><span class="nx">send</span><span class="p">(</span><span class="nx">JSON</span><span class="p">.</span><span class="nx">stringify</span><span class="p">(</span><span class="nx">msg</span><span class="p">));</span>
+<span class="p">};</span>
+</code></pre></div><div class="highlight"><pre class="highlight python tab-python"><code><span class="kn">import</span> <span class="nn">asyncio</span>
+<span class="kn">import</span> <span class="nn">websockets</span>
+<span class="kn">import</span> <span class="nn">json</span>
+
+<span class="c1"># To subscribe to this channel:
+</span><span class="n">msg</span> <span class="o">=</span> \
+    <span class="p">{</span><span class="s">"jsonrpc"</span><span class="p">:</span> <span class="s">"2.0"</span><span class="p">,</span>
+     <span class="s">"method"</span><span class="p">:</span> <span class="s">"public/subscribe"</span><span class="p">,</span>
+     <span class="s">"id"</span><span class="p">:</span> <span class="mi">42</span><span class="p">,</span>
+     <span class="s">"params"</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s">"channels"</span><span class="p">:</span> <span class="p">[</span><span class="s">"block_trade_confirmations.btc"</span><span class="p">]}</span>
+    <span class="p">}</span>
+
+<span class="k">async</span> <span class="k">def</span> <span class="nf">call_api</span><span class="p">(</span><span class="n">msg</span><span class="p">):</span>
+   <span class="k">async</span> <span class="k">with</span> <span class="n">websockets</span><span class="p">.</span><span class="n">connect</span><span class="p">(</span><span class="s">'wss://test.deribit.com/ws/api/v2'</span><span class="p">)</span> <span class="k">as</span> <span class="n">websocket</span><span class="p">:</span>
+       <span class="k">await</span> <span class="n">websocket</span><span class="p">.</span><span class="n">send</span><span class="p">(</span><span class="n">msg</span><span class="p">)</span>
+       <span class="k">while</span> <span class="n">websocket</span><span class="p">.</span><span class="nb">open</span><span class="p">:</span>
+           <span class="n">response</span> <span class="o">=</span> <span class="k">await</span> <span class="n">websocket</span><span class="p">.</span><span class="n">recv</span><span class="p">()</span>
+           <span class="c1"># do something with the notifications...
+</span>           <span class="k">print</span><span class="p">(</span><span class="n">response</span><span class="p">)</span>
+
+<span class="n">asyncio</span><span class="p">.</span><span class="n">get_event_loop</span><span class="p">().</span><span class="n">run_until_complete</span><span class="p">(</span><span class="n">call_api</span><span class="p">(</span><span class="n">json</span><span class="p">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">msg</span><span class="p">)))</span>
+</code></pre></div>
+<blockquote>
+<p>This subscription will send next notifications like this:</p>
+</blockquote>
+<div class="highlight"><pre class="highlight json tab-json"><code><span class="p">{</span><span class="w">
+  </span><span class="nl">"params"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+    </span><span class="nl">"data"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+      </span><span class="nl">"user_id"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="mi">7</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"trades"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="w">
+        </span><span class="p">{</span><span class="w">
+          </span><span class="nl">"price"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="mf">70246.66</span><span class="p">,</span><span class="w">
+          </span><span class="nl">"instrument_name"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"BTC-PERPETUAL"</span><span class="p">,</span><span class="w">
+          </span><span class="nl">"direction"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"buy"</span><span class="p">,</span><span class="w">
+          </span><span class="nl">"amount"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="mi">10</span><span class="w">
+        </span><span class="p">}</span><span class="w">
+      </span><span class="p">],</span><span class="w">
+      </span><span class="nl">"timestamp"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="mi">1711468468131</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"state"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="p">{</span><span class="w">
+        </span><span class="nl">"value"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"rejected"</span><span class="p">,</span><span class="w">
+        </span><span class="nl">"timestamp"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="mi">1711468632693</span><span class="w">
+      </span><span class="p">},</span><span class="w">
+      </span><span class="nl">"role"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"maker"</span><span class="p">,</span><span class="w">
+      </span><span class="nl">"nonce"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"bt-jdqv98"</span><span class="w">
+    </span><span class="p">},</span><span class="w">
+    </span><span class="nl">"channel"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"block_trade_confirmations.btc"</span><span class="w">
+  </span><span class="p">},</span><span class="w">
+  </span><span class="nl">"method"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"subscription"</span><span class="p">,</span><span class="w">
+  </span><span class="nl">"jsonrpc"</span><span class="w"> </span><span class="p">:</span><span class="w"> </span><span class="s2">"2.0"</span><span class="w">
+</span><span class="p">}</span><span class="w">
+</span></code></pre></div>
+<p>Provides notifications regarding block trade approval. Supports filtering by currency.</p>
+
+<p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=block_trade_confirmations.%7Bcurrency%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
+<h3 id='channel-parameters-7'>Channel Parameters</h3>
+<table><thead>
+<tr>
+<th>Parameter</th>
+<th>Required</th>
+<th>Type</th>
+<th>Enum</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>currency</td>
+<td>true</td>
+<td>string</td>
+<td><code>BTC</code><br><code>ETH</code><br><code>USDC</code><br><code>USDT</code><br><code>EURR</code><br><code>any</code></td>
+<td>The currency symbol or <code>&quot;any&quot;</code> for all</td>
+</tr>
+</tbody></table>
+<h3 id='response-174'>Response</h3>
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td>data</td>
+<td><em>object</em></td>
+<td></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;app_name</td>
+<td>string</td>
+<td>The name of the application that executed the block trade on behalf of the user (optional).</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;counterparty_state</td>
+<td><em>object</em></td>
+<td>State of the pending block trade for the other party (optional).</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;timestamp</td>
+<td>integer</td>
+<td>State timestamp.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;value</td>
+<td>string</td>
+<td>State value.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;nonce</td>
+<td>string</td>
+<td>Nonce that can be used to approve or reject pending block trade.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;role</td>
+<td>string</td>
+<td>Trade role of the user: <code>maker</code> or <code>taker</code></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;state</td>
+<td><em>object</em></td>
+<td>State of the pending block trade for current user.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;timestamp</td>
+<td>integer</td>
+<td>State timestamp.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;value</td>
+<td>string</td>
+<td>State value.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;timestamp</td>
+<td>integer</td>
+<td>Timestamp that can be used to approve or reject pending block trade.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;trades</td>
+<td>array of <em>object</em></td>
+<td></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
+<td>number</td>
+<td>Trade amount. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;direction</td>
+<td>string</td>
+<td>Direction: <code>buy</code>, or <code>sell</code></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;instrument_name</td>
+<td>string</td>
+<td>Unique instrument identifier</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;price</td>
+<td>number</td>
+<td>Price in base currency</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;user_id</td>
+<td>integer</td>
+<td>Unique user identifier</td>
+</tr>
+</tbody></table>
 <h2 id='book-instrument_name-group-depth-interval'>book.{instrument_name}.{group}.{depth}.{interval}</h2>
 <blockquote>
 <p><em>Subscriptions are only available via websockets.</em></p>
@@ -42596,7 +43116,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><em>amount</em> indicates the amount of all orders at price level. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.</p></p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=book.%7Binstrument_name%7D.%7Bgroup%7D.%7Bdepth%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-7'>Channel Parameters</h3>
+<h3 id='channel-parameters-8'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -42635,7 +43155,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval.</td>
 </tr>
 </tbody></table>
-<h3 id='response-174'>Response</h3>
+<h3 id='response-175'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -42801,7 +43321,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>The amount for perpetual and futures is in USD units, for options it is in corresponding cryptocurrency contracts, e.g., BTC or ETH.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=book.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-8'>Channel Parameters</h3>
+<h3 id='channel-parameters-9'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -42826,7 +43346,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval.</td>
 </tr>
 </tbody></table>
-<h3 id='response-175'>Response</h3>
+<h3 id='response-176'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -42941,7 +43461,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Publicly available market data used to generate a TradingView candle chart. During a single resolution period, many events can be sent, each with updated values for the recent period.<br/><br/> <strong>NOTICE</strong> When there is no trade during the requested resolution period (e.g. 1 minute), then a filling sample is generated which uses data from the last available trade candle (open and close values).</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=chart.trades.%7Binstrument_name%7D.%7Bresolution%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-9'>Channel Parameters</h3>
+<h3 id='channel-parameters-10'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -42966,7 +43486,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Chart bars resolution given in full minutes or keyword <code>1D</code> (only some specific resolutions are supported)</td>
 </tr>
 </tbody></table>
-<h3 id='response-176'>Response</h3>
+<h3 id='response-177'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43077,7 +43597,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Provides information about current value (price) for Deribit Index</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=deribit_price_index.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-10'>Channel Parameters</h3>
+<h3 id='channel-parameters-11'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43095,7 +43615,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier, matches (base) cryptocurrency with quote currency</td>
 </tr>
 </tbody></table>
-<h3 id='response-177'>Response</h3>
+<h3 id='response-178'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43239,7 +43759,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Provides information about current value (price) for stock exchanges used to calculate Deribit Index</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=deribit_price_ranking.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-11'>Channel Parameters</h3>
+<h3 id='channel-parameters-12'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43257,7 +43777,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier, matches (base) cryptocurrency with quote currency</td>
 </tr>
 </tbody></table>
-<h3 id='response-178'>Response</h3>
+<h3 id='response-179'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43365,7 +43885,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>This subscription provides basic statistics about Deribit Index</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=deribit_price_statistics.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-12'>Channel Parameters</h3>
+<h3 id='channel-parameters-13'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43383,7 +43903,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier, matches (base) cryptocurrency with quote currency</td>
 </tr>
 </tbody></table>
-<h3 id='response-179'>Response</h3>
+<h3 id='response-180'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43484,7 +44004,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Provides volatility index subscription</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=deribit_volatility_index.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-13'>Channel Parameters</h3>
+<h3 id='channel-parameters-14'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43502,7 +44022,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier supported for DVOL</td>
 </tr>
 </tbody></table>
-<h3 id='response-180'>Response</h3>
+<h3 id='response-181'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43593,7 +44113,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Returns calculated (estimated) ending price for given index.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=estimated_expiration_price.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-14'>Channel Parameters</h3>
+<h3 id='channel-parameters-15'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43611,7 +44131,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier, matches (base) cryptocurrency with quote currency</td>
 </tr>
 </tbody></table>
-<h3 id='response-181'>Response</h3>
+<h3 id='response-182'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -43760,7 +44280,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Notifies about changes in instrument ticker (key information about the instrument).</p> <p>The first notification will contain the whole ticker. After that there will only be information about changes in the ticker.</p> <p>This event is sent at most once per second.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=incremental_ticker.%7Binstrument_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-15'>Channel Parameters</h3>
+<h3 id='channel-parameters-16'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -43778,7 +44298,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Instrument name</td>
 </tr>
 </tbody></table>
-<h3 id='response-182'>Response</h3>
+<h3 id='response-183'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44039,7 +44559,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Get notifications about new or terminated instruments of given kind in given currency. <strong>(Please note that our system does not send notifications when currencies are locked. Users are advised to subscribe to the <a href="https://docs.deribit.com/#platform_state">platform_state</a> channel to monitor the state of currencies actively.)</strong></p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=instrument.state.%7Bkind%7D.%7Bcurrency%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-16'>Channel Parameters</h3>
+<h3 id='channel-parameters-17'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44064,7 +44584,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The currency symbol or <code>&quot;any&quot;</code> for all</td>
 </tr>
 </tbody></table>
-<h3 id='response-183'>Response</h3>
+<h3 id='response-184'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44182,7 +44702,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Provides information about options markprices.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=markprice.options.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-17'>Channel Parameters</h3>
+<h3 id='channel-parameters-18'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44200,7 +44720,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier, matches (base) cryptocurrency with quote currency</td>
 </tr>
 </tbody></table>
-<h3 id='response-184'>Response</h3>
+<h3 id='response-185'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44296,7 +44816,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Provide current interest rate - but only for <strong>perpetual</strong> instruments. Other types won&#39;t generate any notification.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=perpetual.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-18'>Channel Parameters</h3>
+<h3 id='channel-parameters-19'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44321,7 +44841,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-185'>Response</h3>
+<h3 id='response-186'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44411,9 +44931,9 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Information about platform state.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=platform_state" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-19'>Channel Parameters</h3>
+<h3 id='channel-parameters-20'>Channel Parameters</h3>
 <p><em>This channel takes no parameters</em></p>
-<h3 id='response-186'>Response</h3>
+<h3 id='response-187'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44502,9 +45022,9 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Information whether unauthorized public requests are allowed</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=platform_state.public_methods_state" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-20'>Channel Parameters</h3>
+<h3 id='channel-parameters-21'>Channel Parameters</h3>
 <p><em>This channel takes no parameters</em></p>
-<h3 id='response-187'>Response</h3>
+<h3 id='response-188'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44588,7 +45108,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Best bid/ask price and size.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=quote.%7Binstrument_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-21'>Channel Parameters</h3>
+<h3 id='channel-parameters-22'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44606,7 +45126,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Instrument name</td>
 </tr>
 </tbody></table>
-<h3 id='response-188'>Response</h3>
+<h3 id='response-189'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44714,7 +45234,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Get notifications about RFQs for instruments in given currency.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=rfq.%7Bcurrency%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-22'>Channel Parameters</h3>
+<h3 id='channel-parameters-23'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44732,7 +45252,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The currency symbol or <code>&quot;any&quot;</code> for all</td>
 </tr>
 </tbody></table>
-<h3 id='response-189'>Response</h3>
+<h3 id='response-190'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -44860,7 +45380,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Key information about the instrument</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=ticker.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-23'>Channel Parameters</h3>
+<h3 id='channel-parameters-24'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -44885,7 +45405,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-190'>Response</h3>
+<h3 id='response-191'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -45155,7 +45675,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Get notifications about trades for an instrument.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=trades.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-24'>Channel Parameters</h3>
+<h3 id='channel-parameters-25'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -45180,7 +45700,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-191'>Response</h3>
+<h3 id='response-192'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -45356,7 +45876,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p>Get notifications about trades in any instrument of a given kind and given currency.</p>
 
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=trades.%7Bkind%7D.%7Bcurrency%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
-<h3 id='channel-parameters-25'>Channel Parameters</h3>
+<h3 id='channel-parameters-26'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -45388,7 +45908,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-192'>Response</h3>
+<h3 id='response-193'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -45559,9 +46079,9 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.access_log" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-26'>Channel Parameters</h3>
+<h3 id='channel-parameters-27'>Channel Parameters</h3>
 <p><em>This method takes no parameters</em></p>
-<h3 id='response-193'>Response</h3>
+<h3 id='response-194'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -45743,7 +46263,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.changes.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-27'>Channel Parameters</h3>
+<h3 id='channel-parameters-28'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -45768,7 +46288,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-194'>Response</h3>
+<h3 id='response-195'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -45815,6 +46335,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -45972,6 +46497,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -46020,11 +46550,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -46495,7 +47020,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.changes.%7Bkind%7D.%7Bcurrency%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-28'>Channel Parameters</h3>
+<h3 id='channel-parameters-29'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -46527,7 +47052,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-195'>Response</h3>
+<h3 id='response-196'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -46574,6 +47099,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -46731,6 +47261,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -46779,11 +47314,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -47263,7 +47793,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.combo_trades.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-29'>Channel Parameters</h3>
+<h3 id='channel-parameters-30'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -47288,7 +47818,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-196'>Response</h3>
+<h3 id='response-197'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -47629,7 +48159,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.combo_trades.%7Bkind%7D.%7Bcurrency%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-30'>Channel Parameters</h3>
+<h3 id='channel-parameters-31'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -47661,7 +48191,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-197'>Response</h3>
+<h3 id='response-198'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -47923,9 +48453,9 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.lock" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-31'>Channel Parameters</h3>
+<h3 id='channel-parameters-32'>Channel Parameters</h3>
 <p><em>This method takes no parameters</em></p>
-<h3 id='response-198'>Response</h3>
+<h3 id='response-199'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -48013,7 +48543,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.mmp_trigger.%7Bindex_name%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-32'>Channel Parameters</h3>
+<h3 id='channel-parameters-33'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -48031,7 +48561,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Index identifier of derivative instrument on the platform</td>
 </tr>
 </tbody></table>
-<h3 id='response-199'>Response</h3>
+<h3 id='response-200'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -48147,7 +48677,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.orders.%7Binstrument_name%7D.raw" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-33'>Channel Parameters</h3>
+<h3 id='channel-parameters-34'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -48165,7 +48695,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Instrument name</td>
 </tr>
 </tbody></table>
-<h3 id='response-200'>Response</h3>
+<h3 id='response-201'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -48202,6 +48732,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -48359,6 +48894,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -48407,11 +48947,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -48523,7 +49058,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.orders.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-34'>Channel Parameters</h3>
+<h3 id='channel-parameters-35'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -48548,7 +49083,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval.</td>
 </tr>
 </tbody></table>
-<h3 id='response-201'>Response</h3>
+<h3 id='response-202'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -48585,6 +49120,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -48742,6 +49282,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -48790,11 +49335,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -48904,7 +49444,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.orders.%7Bkind%7D.%7Bcurrency%7D.raw" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-35'>Channel Parameters</h3>
+<h3 id='channel-parameters-36'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -48929,7 +49469,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The currency symbol or <code>&quot;any&quot;</code> for all</td>
 </tr>
 </tbody></table>
-<h3 id='response-202'>Response</h3>
+<h3 id='response-203'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -48966,6 +49506,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -49123,6 +49668,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -49171,11 +49721,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -49285,7 +49830,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.orders.%7Bkind%7D.%7Bcurrency%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-36'>Channel Parameters</h3>
+<h3 id='channel-parameters-37'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -49317,7 +49862,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval.</td>
 </tr>
 </tbody></table>
-<h3 id='response-203'>Response</h3>
+<h3 id='response-204'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -49354,6 +49899,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;implv</td>
 <td>number</td>
 <td>Implied volatility in percent. (Only if <code>advanced=&quot;implv&quot;</code>)</td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;refresh_amount</td>
+<td>number</td>
+<td>The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;usd</td>
@@ -49511,6 +50061,11 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)</td>
 </tr>
 <tr>
+<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;display_amount</td>
+<td>number</td>
+<td>The actual display amount of iceberg order. Absent for other types of orders.</td>
+</tr>
+<tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;order_type</td>
 <td>string</td>
 <td>Order type: <code>&quot;limit&quot;</code>, <code>&quot;market&quot;</code>, <code>&quot;stop_limit&quot;</code>, <code>&quot;stop_market&quot;</code></td>
@@ -49559,11 +50114,6 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;reduce_only</td>
 <td>boolean</td>
 <td>Optional (not added for spot). &#39;<code>true</code> for reduce-only orders only&#39;</td>
-</tr>
-<tr>
-<td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;max_show</td>
-<td>number</td>
-<td>Maximum amount within an order to be shown to other traders, 0 for invisible order.</td>
 </tr>
 <tr>
 <td>&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;amount</td>
@@ -49700,7 +50250,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.portfolio.%7Bcurrency%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-37'>Channel Parameters</h3>
+<h3 id='channel-parameters-38'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -49718,7 +50268,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>The currency symbol or <code>&quot;any&quot;</code> for all</td>
 </tr>
 </tbody></table>
-<h3 id='response-204'>Response</h3>
+<h3 id='response-205'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -50045,7 +50595,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.trades.%7Binstrument_name%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-38'>Channel Parameters</h3>
+<h3 id='channel-parameters-39'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -50070,7 +50620,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-205'>Response</h3>
+<h3 id='response-206'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -50351,7 +50901,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <p><a href="https://test.deribit.com/api_console?method=%2Fprivate%2Fsubscribe&channels=user.trades.%7Bkind%7D.%7Bcurrency%7D.%7Binterval%7D" target="_blank" rel="noopener noreferrer">Try in API console</a></p>
 
 <aside class='multi-notice'><div>  This is a private subscription; subscribing is only possible when authenticated.</div></aside>
-<h3 id='channel-parameters-39'>Channel Parameters</h3>
+<h3 id='channel-parameters-40'>Channel Parameters</h3>
 <table><thead>
 <tr>
 <th>Parameter</th>
@@ -50383,7 +50933,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <td>Frequency of notifications. Events will be aggregated over this interval. The value <code>raw</code> means no aggregation will be applied <strong>(Please note that <code>raw</code> interval is only available to authorized users)</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-206'>Response</h3>
+<h3 id='response-207'>Response</h3>
 <table><thead>
 <tr>
 <th>Name</th>
@@ -50858,7 +51408,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">11021</td>
 <td style="text-align: left"><code>&quot;post_only_price_modification_not_possible&quot;</code></td>
-<td style="text-align: left">Price modification for post only order is not possible</td>
+<td style="text-align: left">Price modification for post only order is not possible.</td>
 </tr>
 <tr>
 <td style="text-align: left">11022</td>
@@ -50978,12 +51528,12 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">11055</td>
 <td style="text-align: left"><code>&quot;post_only_not_allowed&quot;</code></td>
-<td style="text-align: left">Post only flag not allowed for given order type</td>
+<td style="text-align: left">Post only flag not allowed for given order type.</td>
 </tr>
 <tr>
 <td style="text-align: left">11056</td>
 <td style="text-align: left"><code>&quot;unauthenticated_public_requests_temporarily_disabled&quot;</code></td>
-<td style="text-align: left">Request rejected because of unauthenticated public requests were temporarily disabled</td>
+<td style="text-align: left">Request rejected because of unauthenticated public requests were temporarily disabled.</td>
 </tr>
 <tr>
 <td style="text-align: left">11090</td>
@@ -51173,12 +51723,12 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">13032</td>
 <td style="text-align: left"><code>&quot;non_unique_order_label&quot;</code></td>
-<td style="text-align: left">Request allowed only for orders uniquely identified by given label, more than one match was found</td>
+<td style="text-align: left">Request allowed only for orders uniquely identified by given label, more than one match was foun.</td>
 </tr>
 <tr>
 <td style="text-align: left">13034</td>
 <td style="text-align: left"><code>&quot;no_more_security_keys_allowed&quot;</code></td>
-<td style="text-align: left">Maximal number of tokens allowed reached</td>
+<td style="text-align: left">Maximal number of tokens allowed reached.</td>
 </tr>
 <tr>
 <td style="text-align: left">13035</td>
@@ -51213,7 +51763,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">13403</td>
 <td style="text-align: left"><code>&quot;scope_exceeded&quot;</code></td>
-<td style="text-align: left">Error returned after the user tried to edit / delete an API key using an authorized key connection with insufficient scope</td>
+<td style="text-align: left">Error returned after the user tried to edit / delete an API key using an authorized key connection with insufficient scope.</td>
 </tr>
 <tr>
 <td style="text-align: left">13503</td>
@@ -51238,12 +51788,12 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">13780</td>
 <td style="text-align: left"><code>&quot;move_positions_over_limit&quot;</code></td>
-<td style="text-align: left">The client cannot execute the request yet, and should wait for <code>wait</code> seconds to try again</td>
+<td style="text-align: left">The client cannot execute the request yet, and should wait for <code>wait</code> seconds to try again.</td>
 </tr>
 <tr>
 <td style="text-align: left">13781</td>
 <td style="text-align: left"><code>&quot;coupon_already_used&quot;</code></td>
-<td style="text-align: left">The coupon has already been used by current account</td>
+<td style="text-align: left">The coupon has already been used by current account.</td>
 </tr>
 <tr>
 <td style="text-align: left">13791</td>
@@ -51263,7 +51813,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">13888</td>
 <td style="text-align: left"><code>&quot;timed_out&quot;</code></td>
-<td style="text-align: left">Server did not manage to process request when it was valid (<code>valid_until</code>)</td>
+<td style="text-align: left">Server did not manage to process request when it was valid (<code>valid_until</code>).</td>
 </tr>
 <tr>
 <td style="text-align: left">13901</td>
@@ -51278,12 +51828,82 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">13903</td>
 <td style="text-align: left"><code>&quot;too_many_quotes&quot;</code></td>
-<td style="text-align: left">Number of qoutes (in Mass Quotes requests) per second exceeded.</td>
+<td style="text-align: left">Number of quotes (in Mass Quotes requests) per second exceeded.</td>
 </tr>
 <tr>
 <td style="text-align: left">13904</td>
 <td style="text-align: left"><code>&quot;security_key_setup_required&quot;</code></td>
 <td style="text-align: left">Not allowed without a full security key setup.</td>
+</tr>
+<tr>
+<td style="text-align: left">13905</td>
+<td style="text-align: left"><code>&quot;too_many_quotes_per_block_rfq&quot;</code></td>
+<td style="text-align: left">Number of quotes for single block rfq exceeded.</td>
+</tr>
+<tr>
+<td style="text-align: left">13906</td>
+<td style="text-align: left"><code>&quot;too_many_quotes_per_block_rfq_side&quot;</code></td>
+<td style="text-align: left">Number of quotes per single block rfq side exceeded.</td>
+</tr>
+<tr>
+<td style="text-align: left">13907</td>
+<td style="text-align: left"><code>&quot;not_fully_filled&quot;</code></td>
+<td style="text-align: left">Block Rfq trade cannot be fully filled with matched quotes.</td>
+</tr>
+<tr>
+<td style="text-align: left">13907</td>
+<td style="text-align: left"><code>&quot;too_many_open_block_rfqs&quot;</code></td>
+<td style="text-align: left">Number of open block rfq by taker exceeds configured max amount.</td>
+</tr>
+<tr>
+<td style="text-align: left">13910</td>
+<td style="text-align: left"><code>&quot;quote_crossed&quot;</code></td>
+<td style="text-align: left">Quote placed by the maker crosses an already placed quote by the same maker.</td>
+</tr>
+<tr>
+<td style="text-align: left">13911</td>
+<td style="text-align: left"><code>&quot;max_broker_client_count&quot;</code></td>
+<td style="text-align: left">Number of broker client&#39;s exceeds allowed max amount.</td>
+</tr>
+<tr>
+<td style="text-align: left">13912</td>
+<td style="text-align: left"><code>&quot;broker_cannot_be_client&quot;</code></td>
+<td style="text-align: left">Broker accounts cannot be clients of other brokers.</td>
+</tr>
+<tr>
+<td style="text-align: left">13913</td>
+<td style="text-align: left"><code>&quot;broker_already_linked&quot;</code></td>
+<td style="text-align: left">User has already been linked to this broker.</td>
+</tr>
+<tr>
+<td style="text-align: left">13914</td>
+<td style="text-align: left"><code>&quot;user_is_a_broker_client&quot;</code></td>
+<td style="text-align: left">User is a client of a broker account.</td>
+</tr>
+<tr>
+<td style="text-align: left">13915</td>
+<td style="text-align: left"><code>&quot;user_is_not_a_broker&quot;</code></td>
+<td style="text-align: left">User account is not configured as broker account.</td>
+</tr>
+<tr>
+<td style="text-align: left">13916</td>
+<td style="text-align: left"><code>&quot;app_registered_to_broker&quot;</code></td>
+<td style="text-align: left">Application is registered to a broker.</td>
+</tr>
+<tr>
+<td style="text-align: left">13917</td>
+<td style="text-align: left"><code>&quot;account_quote_limit_crossed&quot;</code></td>
+<td style="text-align: left">Block Rfq quote limits set for the account were crossed.</td>
+</tr>
+<tr>
+<td style="text-align: left">13918</td>
+<td style="text-align: left"><code>&quot;inverse_future_cross_trading&quot;</code></td>
+<td style="text-align: left">Placed block rfq quote would cross trade inverse futures with block rfq quote limits set on the account.</td>
+</tr>
+<tr>
+<td style="text-align: left">13919</td>
+<td style="text-align: left"><code>&quot;client_of_main_account&quot;</code></td>
+<td style="text-align: left">Subaccounts of brokers cannot be linked to their own broker account.</td>
 </tr>
 <tr>
 <td style="text-align: left">-32602</td>
@@ -51293,7 +51913,7 @@ required by JSON-RPC and part dedicated for subscription data.</p>
 <tr>
 <td style="text-align: left">-32600</td>
 <td style="text-align: left"><code>&quot;request entity too large&quot;</code></td>
-<td style="text-align: left">Error thrown when body size in POST request or single frame in websocket connection frame exceeds the limit (32 kB)</td>
+<td style="text-align: left">Error thrown when body size in POST request or single frame in websocket connection frame exceeds the limit (32 kB).</td>
 </tr>
 <tr>
 <td style="text-align: left">-32601</td>
@@ -51581,7 +52201,7 @@ only.</p>
 
 <p><code>CancelOnDisconnect</code>(<code>9001</code>) controls &quot;Close on Disconnect&quot;. If this tag is not
 provided, the default setting from the account is used.</p>
-<h3 id='response-207'>Response</h3>
+<h3 id='response-208'>Response</h3>
 <p>When the login is successful, the server will echo back the request.</p>
 
 <p>If the login was not successful, the server will respond with a
@@ -51641,7 +52261,7 @@ session should be considered lost and corrective action should be initiated.</p>
 <td>The identifier when responding to the <a href="#test-request-1"><code>Test Request</code>(<code>1</code>)</a> message. When not responding to a <code>Test Request</code>(<code>1</code>) message, this tag can be left out</td>
 </tr>
 </tbody></table>
-<h3 id='response-208'>Response</h3>
+<h3 id='response-209'>Response</h3>
 <p>When the heartbeat has been received successfully, the server will echo back the
 request as confirmation.</p>
 <h2 id='test-request-1'><code>Test Request</code>(<code>1</code>)</h2>
@@ -51763,7 +52383,7 @@ header is ignored.</p>
 <td>New Sequence Number</td>
 </tr>
 </tbody></table>
-<h3 id='response-209'>Response</h3>
+<h3 id='response-210'>Response</h3>
 <p>In reply to <code>Sequence Reset</code>(<code>4</code>), the exchange replies with <code>Resend
 Request</code>(<code>2</code>) with <code>BeginSeqNo</code>(<code>7</code>) and <code>EndSeqNo</code>(<code>16</code>) equal to the passed
 <code>NewSeqNo</code>(<code>36</code>) in case of success. In case of wrong arguments, the server
@@ -51847,7 +52467,7 @@ messages starting from the sequence number equal to the <code>NewSeqNo</code>(<c
 <td>Optional parameter for limiting output by the <code>SecurityType</code>. Describes type of security.<p> Possible values: <ul><li><code>FXSPOT</code> for currency exchange spot</li><li><code>FUT</code> for futures,</li><li> <code>OPT</code> for options,</li> <li> <code>FUTCO</code> for future combo,</li> <li><code>OPTCO</code> for option combo</li><li><code>INDEX</code> for indexes</li></ul></td>
 </tr>
 </tbody></table>
-<h3 id='response-210'>Response</h3>
+<h3 id='response-211'>Response</h3>
 <p>The server will respond with a <a href="#security-list-y"><code>Security List</code>(<code>y</code>)</a> message,
 where the <code>SecurityReq</code>(<code>320</code>) is equal to that of the request.</p>
 <h2 id='security-list-y'><code>Security List</code>(<code>y</code>)</h2>
@@ -52220,7 +52840,7 @@ combinations are:</p>
 
 <p>If multiple instrument symbols are specified then the system responds with
 multiple market data messages corresponding to those instruments.</p>
-<h3 id='response-211'>Response</h3>
+<h3 id='response-212'>Response</h3>
 <p>If the server is unable to supply the requested data, it will respond with a
 <a href="#market-data-request-reject-y"><code>Market Data Request Reject</code>(<code>Y</code>)</a> message.</p>
 
@@ -52738,11 +53358,18 @@ exchange.</p>
 <td>Price per unit of quantity</td>
 </tr>
 <tr>
-<td>210</td>
-<td><code>MaxShow</code></td>
+<td>1138</td>
+<td><code>DisplayQty</code></td>
 <td>Qty</td>
 <td>No</td>
-<td>Maximum quantity within an order to be shown to other customers</td>
+<td>The (max) quantity to be displayed in the orderbook. Setting the <code>DisplayQty (1138)</code> = 0 is interpreted as no hidden volume, i.e. the full order quantity is displayed to the market. Omitting the field gives the same result.</td>
+</tr>
+<tr>
+<td>1088</td>
+<td><code>RefreshQty</code></td>
+<td>Qty</td>
+<td>No</td>
+<td>Defines the quantity used to refresh <code>DisplayQty</code>.</td>
 </tr>
 <tr>
 <td>854</td>
@@ -52794,7 +53421,7 @@ exchange.</p>
 <td>Selects condition trigger method for algo orders. Valid values:<p><ul><li><code>1</code> = mark price,</li><li><code>2</code> = trade,</li><li><code>3</code> = index</li></ul></p></td>
 </tr>
 </tbody></table>
-<h3 id='response-212'>Response</h3>
+<h3 id='response-213'>Response</h3>
 <p>Upon receiving a new order, the exchange responds with the <code>Execution
 Report</code>(<code>8</code>) message communicating whether the order was accepted or rejected.</p>
 
@@ -52983,11 +53610,11 @@ Report</code>(<code>8</code>) message communicating whether the order was accept
 <td>Average execution price or 0.0 if not executed yet or rejected</td>
 </tr>
 <tr>
-<td>210</td>
-<td><code>MaxShow</code></td>
+<td>1138</td>
+<td><code>DisplayQty</code></td>
 <td>Qty</td>
 <td>No</td>
-<td>Maximum quantity (e.g. number of shares) within an order to be shown to other customers</td>
+<td>The (max) quantity to be displayed in the orderbook.</td>
 </tr>
 <tr>
 <td>9008</td>
@@ -53380,7 +54007,7 @@ option <code>10</code> of the <code>MassCancelRequestType</code>(<code>530</code
 <td>Whether or not to reject incoming quotes for 1 second after cancelling</td>
 </tr>
 </tbody></table>
-<h3 id='response-213'>Response</h3>
+<h3 id='response-214'>Response</h3>
 <p>After the cancellation, the server responds with
 an <code>Order Mass Cancel Report</code>(<code>r</code>).</p>
 <h2 id='order-mass-cancel-report-r'><code>Order Mass Cancel Report</code>(<code>r</code>)</h2>
@@ -53569,7 +54196,7 @@ to closed orders.</p>
 <!-- *To request historical orders*: set `MassStatusReqType=10` and specify `Currency` or `Symbol` for the request. To include fully unfilled orders in the response, set custom tag `OrderHistoryIncludeUnfilled` (`9037`) to `Y`. The default maximum number of reports is 100, use `TotNumReports` in the request for the different number if required (maximum 1000 reports is allowed, and `OrderHistoryOffset` (`9039`) custom tag can be used for the pagination). The server will respond with a series of `Execution Reports`(`8`) messages, where the first message contains `MassStatusReqType=7`
 and `TotNumReports` will be set to the number of reports to be expected as a
 follow-up. Open unfilled orders are not included in the historical data.  -->
-<h3 id='response-214'>Response</h3>
+<h3 id='response-215'>Response</h3>
 <p>When the client requests the status of current orders, the exchange should reply
 with a series of special <code>Execution Reports</code>(<code>8</code>), one for every order
 requested.</p>
@@ -53731,11 +54358,11 @@ requested.</p>
 <td>Average execution price or 0.0 if not executed yet or rejected</td>
 </tr>
 <tr>
-<td>210</td>
-<td><code>MaxShow</code></td>
+<td>1138</td>
+<td><code>DisplayQty</code></td>
 <td>Qty</td>
 <td>No</td>
-<td>Maximum quantity (e.g. number of shares) within an order to be shown to other customers in Contract units corresponding to the ContractMultiplier in SecurityList</td>
+<td>The (max) quantity to be displayed in the orderbook. Contract units corresponding to the ContractMultiplier in SecurityList</td>
 </tr>
 <tr>
 <td>9008</td>
@@ -53935,7 +54562,7 @@ Position Report.</p>
 <td>To request for certain currency only. If it is missing, all currencies are reported</td>
 </tr>
 </tbody></table>
-<h3 id='response-215'>Response</h3>
+<h3 id='response-216'>Response</h3>
 <p>The server will respond with a <a href="#position-report-ap"><code>Position Report</code>(<code>AP</code>)</a>
 message.</p>
 <h2 id='position-report-ap'><code>Position Report</code>(<code>AP</code>)</h2>
@@ -54120,12 +54747,12 @@ info.</p>
 <td>Currency of the report. See <a href="#security-list-request-x"><code>Security List Request</code>(<code>x</code>)</a>. Default is BTC. <p>If <code>CROSS</code> is given as currency and user has cross collateral enabled, only the following fields are returned:</p><p><ul><li>100001 <code>DeribitUserEquity</code></li><li>100003 <code>DeribitUserInitialMargin</code></li><li>100004 <code>DeribitUserMaintenanceMargin</code></li><li>100013 <code>DeribitMarginBalance</code></li></ul></p></td>
 </tr>
 </tbody></table>
-<h3 id='response-216'>Response</h3>
+<h3 id='response-217'>Response</h3>
 <p>The server will respond with a <code>User Response</code>(<code>BF</code>) message.</p>
 <h2 id='user-response-bf'><code>User Response</code>(<code>BF</code>)</h2>
 <p>This message is used to respond to a <a href="#user-request-be"><code>USER REQUEST</code>(<code>BE</code>)</a>
 message, it reports the status of the user and user&#39;s account info.</p>
-<h3 id='response-217'>Response</h3>
+<h3 id='response-218'>Response</h3>
 <table><thead>
 <tr>
 <th>Tag</th>
@@ -54333,7 +54960,7 @@ orders by <code>OrigClOrdId</code> is noticeably faster.</p>
 <td>Order Market Maker Protection (MMP) flag, if it is absent then the current MMP flag of the order is not changed. <code>N</code> removes the flag if it is set. <strong>Important: manual admin action is necessary to activate Market Maker Protection (MMP) for an account</strong></td>
 </tr>
 </tbody></table>
-<h3 id='response-218'>Response</h3>
+<h3 id='response-219'>Response</h3>
 <p>See <code>New Order Single</code>(<code>D</code>) response</p>
 <h2 id='execution-reports-8-about-order-changes'><code>Execution Reports</code>(<code>8</code>) about order changes</h2><h3 id='notification'>Notification</h3>
 <p>The report <code>Execution Reports</code>(<code>8</code>) is similar to New Order Single or
@@ -54517,11 +55144,11 @@ Cancel/Replace responses</p>
 <td>Average execution price or 0.0 if not executed yet or rejected</td>
 </tr>
 <tr>
-<td>210</td>
-<td><code>MaxShow</code></td>
+<td>1138</td>
+<td><code>DisplayQty</code></td>
 <td>Qty</td>
 <td>No</td>
-<td>Maximum quantity (e.g. number of shares) within an order to be shown to other customers</td>
+<td>The (max) quantity to be displayed in the orderbook.</td>
 </tr>
 <tr>
 <td>100012</td>
@@ -54677,13 +55304,13 @@ Cancel/Replace responses</p>
 <td><code>0</code> = <code>Snapshot</code>, <code>1</code> = <code>Snapshot + Updates</code> (<code>Subscribe</code>), <code>2</code> = <code>Unsubscribe</code> <p>(Please note that our system does not send notifications when currencies are <b>locked</b>. Users are advised to subscribe to the <a href="https://docs.deribit.com/#platform_state">platform_state</a> channel to monitor the state of currencies actively.)</p></td>
 </tr>
 </tbody></table>
-<h3 id='response-219'>Response</h3>
+<h3 id='response-220'>Response</h3>
 <p>The server will respond with a <a href="#security-status-f"><code>Security Status</code> (<code>f</code>)</a>
 message.</p>
 <h2 id='security-status-f'><code>Security Status</code> (<code>f</code>)</h2>
 <p>The <code>Security Status</code> (<code>f</code>) message provides for the ability to report changes
 in status to a security.</p>
-<h3 id='response-220'>Response</h3>
+<h3 id='response-221'>Response</h3>
 <table><thead>
 <tr>
 <th>Tag</th>
@@ -54844,7 +55471,7 @@ used to set or get the limits for Market Maker Protection (MMP) for a currency p
 <p><strong>Important: manual admin action is necessary to activate Market Maker
 Protection (MMP) for an account.</strong> This message is sent by the server in reply
 to <a href="#mmprotection-limits-mm"><code>MMProtection Limits</code> (<code>MM</code>)</a> or <a href="#mmprotection-reset-mz"><code>MMProtectionReset</code> (<code>MZ</code>)</a></p>
-<h3 id='response-221'>Response</h3>
+<h3 id='response-222'>Response</h3>
 <table><thead>
 <tr>
 <th>Tag</th>
@@ -54919,7 +55546,7 @@ Protection (MMP) for an account.</strong> This message resets Market Maker Prote
 <td>A custom tag of MMP Group</td>
 </tr>
 </tbody></table>
-<h3 id='response-222'>Response</h3>
+<h3 id='response-223'>Response</h3>
 <p>The server sends <code>MMProtection Result (MR)</code> message as a response.</p>
 <h2 id='security-definition-request-c'><code>Security Definition Request</code> (<code>c</code>)</h2>
 <p>Request a specific Security to be traded with the second party. The request
@@ -55002,7 +55629,7 @@ end-points depending on <code>SecurityRequestType (321)</code> tag value).</p>
 <td>Positive integer for the strategy</td>
 </tr>
 </tbody></table>
-<h3 id='response-223'>Response</h3>
+<h3 id='response-224'>Response</h3>
 <p>The server sends <a href="#security-definition-d"><code>Security Definition (d)</code></a> message as
 a response, or rejects the request</p>
 <h2 id='security-definition-d'><code>Security Definition</code> (<code>d</code>)</h2>
@@ -55227,7 +55854,7 @@ via RFQ subscription or in the snapshots.</p>
 <td>Order quantity in contracts</td>
 </tr>
 </tbody></table>
-<h3 id='response-224'>Response</h3>
+<h3 id='response-225'>Response</h3>
 <p>In case of success, the response will be
 a <a href="#quote-status-report-ai"><code>Quote Status Report (AI)</code></a>. If the request fails,
 the <a href="#quote-request-reject-ag"><code>Quote Request Reject (AG)</code></a> will be sent, or session level
@@ -55392,7 +56019,7 @@ of the current quotes in the system.</p>
 <td>Subscription Request Type to get notifications about new or terminated instruments. Valid values: <ul><li> <code>0</code> = Snapshot,</li> <li><code>1</code> = Snapshot + Updates (Subscribe),</li> <li><code>2</code> = Disable previous Snapshot + Update Request (Unsubscribe)</li></ul></td>
 </tr>
 </tbody></table>
-<h3 id='response-225'>Response</h3>
+<h3 id='response-226'>Response</h3>
 <p>RFQ request can be used to request existing
 <a href="#quote-request-r"><code>Quote Requests (R)</code></a> as well as to subscribe for new
 <a href="#quote-request-r"><code>Quote Requests (R)</code></a> and <a href="#quote-status-report-ai"><code>Quote Status Reports (AI)</code></a>
@@ -56009,7 +56636,12 @@ MassQuote
 <td>Max Delta to cancel by delta range</td>
 </tr>
 </tbody></table>
-<h2 id='changes-log'>Changes Log</h2><h3 id='release-06-03-2025'>Release 06.03.2025</h3>
+<h2 id='changes-log'>Changes Log</h2><h3 id='release-10-06-2025'>Release 10.06.2025</h3>
+<ul>
+<li><code>MaxShow(210)</code> is replaced with <code>DisplayQty(1138)</code>. The iceberg orders cannot be fully invisible anymore. Setting the <code>DisplayQty (1138)</code> = 0 is interpreted as no hidden volume, i.e. the full order quantity is displayed to the market. Omitting the field gives the same result.</li>
+<li><code>Execution Reports</code> (<code>8</code>): added nonmandatory tag <code>RefreshQty</code> (<code>1088</code>)</li>
+</ul>
+<h3 id='release-06-03-2025'>Release 06.03.2025</h3>
 <ul>
 <li>Support for non-printable ASCII characters (such as control characters ranging from 0x00 to 0x1F) in string values has been removed to ensure compliance with the WS/REST API. Attempting to use non-printable ASCII characters will now result in a decoding error.</li>
 </ul>

--- a/codegen/deribit.json
+++ b/codegen/deribit.json
@@ -9,9 +9,9 @@
                 "enums": [
                     {
                         "items": [
-                            "refresh_token",
                             "client_signature",
-                            "client_credentials"
+                            "client_credentials",
+                            "refresh_token"
                         ],
                         "name": "grant_type"
                     }
@@ -1295,8 +1295,8 @@
                 "enums": [
                     {
                         "items": [
-                            "connection",
-                            "account"
+                            "account",
+                            "connection"
                         ],
                         "name": "scope"
                     }
@@ -1441,8 +1441,8 @@
                 "enums": [
                     {
                         "items": [
-                            "connection",
-                            "account"
+                            "account",
+                            "connection"
                         ],
                         "name": "scope"
                     }
@@ -1587,8 +1587,8 @@
                 "enums": [
                     {
                         "items": [
-                            "connection",
-                            "account"
+                            "account",
+                            "connection"
                         ],
                         "name": "scope"
                     }
@@ -2272,8 +2272,8 @@
                 "enums": [
                     {
                         "items": [
-                            "steth",
-                            "usde"
+                            "usde",
+                            "steth"
                         ],
                         "name": "currency"
                     }
@@ -2532,7 +2532,7 @@
         }
     },
     {
-        "comment": "Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).",
+        "comment": "Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).\nNote - For real-time updates, we recommend using the WebSocket subscription to ticker.{instrument_name}.{interval} instead of polling this endpoint.",
         "endpoint": {
             "name": "public_get_book_summary_by_currency",
             "path": "/public/get_book_summary_by_currency",
@@ -2541,21 +2541,21 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     }
@@ -4663,50 +4663,50 @@
                 "enums": [
                     {
                         "items": [
-                            "eurr_usdt",
-                            "eth_eurr",
-                            "eth_usdc",
-                            "sol_usdt",
-                            "btcdvol_usdc",
-                            "usdc_usdt",
-                            "trump_usdc",
-                            "btc_usde",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "eth_usde",
-                            "eurr_usdc",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "eth_btc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "usyc_usdc",
-                            "btc_usyc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "steth_usdt",
-                            "usde_usdt",
-                            "paxg_btc",
-                            "steth_usdc",
-                            "link_usdc",
-                            "doge_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
-                            "eth_usyc",
                             "avax_usdc",
-                            "btc_usd",
-                            "shib_usdc",
-                            "btc_usdt",
-                            "eth_usdt",
+                            "paxg_btc",
+                            "btc_usyc",
+                            "algo_usdc",
+                            "dot_usdc",
                             "btc_eurr",
-                            "steth_eth",
+                            "eth_eurr",
+                            "eth_usde",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "eurr_usdt",
+                            "link_usdc",
+                            "btc_usde",
+                            "eth_usyc",
+                            "eth_btc",
+                            "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
+                            "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "usyc_usdc",
+                            "steth_usdc",
+                            "steth_usdt",
+                            "eth_usd",
+                            "eth_usdt",
+                            "ada_usdc",
+                            "sol_usdt",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "usdc_usdt",
+                            "usde_usdt",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "eurr_usdc",
+                            "bnb_usdc",
+                            "steth_eth",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -4974,69 +4974,69 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "grouped",
                             "ETH",
+                            "USDC",
                             "any",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
+                            "future",
                             "any",
-                            "option",
-                            "future"
+                            "option"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "eurr_usdt",
-                            "eth_eurr",
-                            "eth_usdc",
-                            "sol_usdt",
-                            "btcdvol_usdc",
-                            "usdc_usdt",
-                            "trump_usdc",
-                            "btc_usde",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "eth_usde",
-                            "eurr_usdc",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "eth_btc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "usyc_usdc",
-                            "btc_usyc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "steth_usdt",
-                            "usde_usdt",
-                            "paxg_btc",
-                            "steth_usdc",
-                            "link_usdc",
-                            "doge_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
-                            "eth_usyc",
                             "avax_usdc",
-                            "btc_usd",
-                            "shib_usdc",
-                            "btc_usdt",
-                            "eth_usdt",
+                            "paxg_btc",
+                            "btc_usyc",
+                            "algo_usdc",
+                            "dot_usdc",
                             "btc_eurr",
-                            "steth_eth",
+                            "eth_eurr",
+                            "eth_usde",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "eurr_usdt",
+                            "link_usdc",
+                            "btc_usde",
+                            "eth_usyc",
+                            "eth_btc",
+                            "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
+                            "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "usyc_usdc",
+                            "steth_usdc",
+                            "steth_usdt",
+                            "eth_usd",
+                            "eth_usdt",
+                            "ada_usdc",
+                            "sol_usdt",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "usdc_usdt",
+                            "usde_usdt",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "eurr_usdc",
+                            "bnb_usdc",
+                            "steth_eth",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "currency_pair"
                     }
@@ -5269,9 +5269,9 @@
                 "enums": [
                     {
                         "items": [
-                            "24h",
                             "8h",
-                            "1m"
+                            "1m",
+                            "24h"
                         ],
                         "name": "length"
                     }
@@ -6033,11 +6033,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -6244,50 +6244,50 @@
                 "enums": [
                     {
                         "items": [
-                            "eurr_usdt",
-                            "eth_eurr",
-                            "eth_usdc",
-                            "sol_usdt",
-                            "btcdvol_usdc",
-                            "usdc_usdt",
-                            "trump_usdc",
-                            "btc_usde",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "eth_usde",
-                            "eurr_usdc",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "eth_btc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "usyc_usdc",
-                            "btc_usyc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "steth_usdt",
-                            "usde_usdt",
-                            "paxg_btc",
-                            "steth_usdc",
-                            "link_usdc",
-                            "doge_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
-                            "eth_usyc",
                             "avax_usdc",
-                            "btc_usd",
-                            "shib_usdc",
-                            "btc_usdt",
-                            "eth_usdt",
+                            "paxg_btc",
+                            "btc_usyc",
+                            "algo_usdc",
+                            "dot_usdc",
                             "btc_eurr",
-                            "steth_eth",
+                            "eth_eurr",
+                            "eth_usde",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "eurr_usdt",
+                            "link_usdc",
+                            "btc_usde",
+                            "eth_usyc",
+                            "eth_btc",
+                            "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
+                            "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "usyc_usdc",
+                            "steth_usdc",
+                            "steth_usdt",
+                            "eth_usd",
+                            "eth_usdt",
+                            "ada_usdc",
+                            "sol_usdt",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "usdc_usdt",
+                            "usde_usdt",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "eurr_usdc",
+                            "bnb_usdc",
+                            "steth_eth",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -7513,7 +7513,7 @@
         }
     },
     {
-        "comment": "Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.",
+        "comment": "Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.\nNote - This endpoint has distinct API rate limiting requirements: 1 request per 10 seconds, with a burst of 5. To avoid rate limits, we recommend using either the REST requests for server-cached data or the WebSocket subscription to instrument_state.{kind}.{currency} for real-time updates. For more information, see Rate Limits.",
         "endpoint": {
             "name": "public_get_instruments",
             "path": "/public/get_instruments",
@@ -7522,22 +7522,22 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
                             "any",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     }
@@ -8481,19 +8481,19 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "bankruptcy",
+                            "delivery",
                             "settlement",
-                            "delivery"
+                            "bankruptcy"
                         ],
                         "name": "type"
                     }
@@ -8943,9 +8943,9 @@
                 "enums": [
                     {
                         "items": [
-                            "bankruptcy",
+                            "delivery",
                             "settlement",
-                            "delivery"
+                            "bankruptcy"
                         ],
                         "name": "type"
                     }
@@ -9395,23 +9395,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
@@ -9960,23 +9960,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
@@ -11697,14 +11697,14 @@
                 "enums": [
                     {
                         "items": [
-                            "1000",
-                            "10",
-                            "1",
-                            "5",
-                            "50",
                             "10000",
+                            "1000",
+                            "5",
+                            "10",
                             "100",
-                            "20"
+                            "1",
+                            "20",
+                            "50"
                         ],
                         "name": "depth"
                     }
@@ -12722,14 +12722,14 @@
                 "enums": [
                     {
                         "items": [
-                            "1000",
-                            "10",
-                            "1",
-                            "5",
-                            "50",
                             "10000",
+                            "1000",
+                            "5",
+                            "10",
                             "100",
-                            "20"
+                            "1",
+                            "20",
+                            "50"
                         ],
                         "name": "depth"
                     }
@@ -13747,21 +13747,21 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     }
@@ -14059,9 +14059,9 @@
                 "enums": [
                     {
                         "items": [
-                            "derivative",
+                            "spot",
                             "all",
-                            "spot"
+                            "derivative"
                         ],
                         "name": "type"
                     }
@@ -14692,18 +14692,18 @@
                 "enums": [
                     {
                         "items": [
-                            "30",
-                            "120",
-                            "15",
-                            "1D",
-                            "720",
-                            "10",
-                            "3",
-                            "60",
-                            "5",
                             "180",
                             "360",
-                            "1"
+                            "5",
+                            "10",
+                            "60",
+                            "720",
+                            "30",
+                            "15",
+                            "3",
+                            "120",
+                            "1",
+                            "1D"
                         ],
                         "name": "resolution"
                     }
@@ -15105,21 +15105,21 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "1D",
                             "60",
+                            "43200",
                             "3600",
                             "1",
-                            "43200"
+                            "1D"
                         ],
                         "name": "resolution"
                     }
@@ -16363,21 +16363,21 @@
                 "enums": [
                     {
                         "items": [
-                            "stop_market",
-                            "trailing_stop",
-                            "take_limit",
-                            "market_limit",
                             "stop_limit",
+                            "market_limit",
+                            "limit",
+                            "trailing_stop",
+                            "stop_market",
                             "take_market",
-                            "market",
-                            "limit"
+                            "take_limit",
+                            "market"
                         ],
                         "name": "type"
                     },
                     {
                         "items": [
-                            "immediate_or_cancel",
                             "good_til_day",
+                            "immediate_or_cancel",
                             "fill_or_kill",
                             "good_til_cancelled"
                         ],
@@ -16385,32 +16385,32 @@
                     },
                     {
                         "items": [
-                            "last_price",
+                            "index_price",
                             "mark_price",
-                            "index_price"
+                            "last_price"
                         ],
                         "name": "trigger"
                     },
                     {
                         "items": [
-                            "usd",
-                            "implv"
+                            "implv",
+                            "usd"
                         ],
                         "name": "advanced"
                     },
                     {
                         "items": [
+                            "one_triggers_other",
                             "one_triggers_one_cancels_other",
-                            "one_cancels_other",
-                            "one_triggers_other"
+                            "one_cancels_other"
                         ],
                         "name": "linked_order_type"
                     },
                     {
                         "items": [
                             "complete_fill",
-                            "incremental",
-                            "first_hit"
+                            "first_hit",
+                            "incremental"
                         ],
                         "name": "trigger_fill_condition"
                     }
@@ -16508,8 +16508,8 @@
                         }
                     },
                     {
-                        "comment": "Maximum amount within an order to be shown to other customers, 0 for invisible order",
-                        "name": "max_show",
+                        "comment": "Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.",
+                        "name": "display_amount",
                         "required": "false",
                         "type": {
                             "enums": [],
@@ -16671,28 +16671,28 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 },
                                 {
                                     "items": [
-                                        "stop_market",
-                                        "trailing_stop",
-                                        "take_limit",
-                                        "market_limit",
                                         "stop_limit",
+                                        "market_limit",
+                                        "limit",
+                                        "trailing_stop",
+                                        "stop_market",
                                         "take_market",
-                                        "market",
-                                        "limit"
+                                        "take_limit",
+                                        "market"
                                     ],
                                     "name": "type"
                                 },
                                 {
                                     "items": [
-                                        "immediate_or_cancel",
                                         "good_til_day",
+                                        "immediate_or_cancel",
                                         "fill_or_kill",
                                         "good_til_cancelled"
                                     ],
@@ -16700,9 +16700,9 @@
                                 },
                                 {
                                     "items": [
-                                        "last_price",
+                                        "index_price",
                                         "mark_price",
-                                        "index_price"
+                                        "last_price"
                                     ],
                                     "name": "trigger"
                                 }
@@ -17067,6 +17067,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -17468,6 +17481,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -17595,19 +17621,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -18221,21 +18234,21 @@
                 "enums": [
                     {
                         "items": [
-                            "stop_market",
-                            "trailing_stop",
-                            "take_limit",
-                            "market_limit",
                             "stop_limit",
+                            "market_limit",
+                            "limit",
+                            "trailing_stop",
+                            "stop_market",
                             "take_market",
-                            "market",
-                            "limit"
+                            "take_limit",
+                            "market"
                         ],
                         "name": "type"
                     },
                     {
                         "items": [
-                            "immediate_or_cancel",
                             "good_til_day",
+                            "immediate_or_cancel",
                             "fill_or_kill",
                             "good_til_cancelled"
                         ],
@@ -18243,32 +18256,32 @@
                     },
                     {
                         "items": [
-                            "last_price",
+                            "index_price",
                             "mark_price",
-                            "index_price"
+                            "last_price"
                         ],
                         "name": "trigger"
                     },
                     {
                         "items": [
-                            "usd",
-                            "implv"
+                            "implv",
+                            "usd"
                         ],
                         "name": "advanced"
                     },
                     {
                         "items": [
+                            "one_triggers_other",
                             "one_triggers_one_cancels_other",
-                            "one_cancels_other",
-                            "one_triggers_other"
+                            "one_cancels_other"
                         ],
                         "name": "linked_order_type"
                     },
                     {
                         "items": [
                             "complete_fill",
-                            "incremental",
-                            "first_hit"
+                            "first_hit",
+                            "incremental"
                         ],
                         "name": "trigger_fill_condition"
                     }
@@ -18366,8 +18379,8 @@
                         }
                     },
                     {
-                        "comment": "Maximum amount within an order to be shown to other customers, 0 for invisible order",
-                        "name": "max_show",
+                        "comment": "Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.",
+                        "name": "display_amount",
                         "required": "false",
                         "type": {
                             "enums": [],
@@ -18529,28 +18542,28 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 },
                                 {
                                     "items": [
-                                        "stop_market",
-                                        "trailing_stop",
-                                        "take_limit",
-                                        "market_limit",
                                         "stop_limit",
+                                        "market_limit",
+                                        "limit",
+                                        "trailing_stop",
+                                        "stop_market",
                                         "take_market",
-                                        "market",
-                                        "limit"
+                                        "take_limit",
+                                        "market"
                                     ],
                                     "name": "type"
                                 },
                                 {
                                     "items": [
-                                        "immediate_or_cancel",
                                         "good_til_day",
+                                        "immediate_or_cancel",
                                         "fill_or_kill",
                                         "good_til_cancelled"
                                     ],
@@ -18558,9 +18571,9 @@
                                 },
                                 {
                                     "items": [
-                                        "last_price",
+                                        "index_price",
                                         "mark_price",
-                                        "index_price"
+                                        "last_price"
                                     ],
                                     "name": "trigger"
                                 }
@@ -18925,6 +18938,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -19326,6 +19352,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -19453,19 +19492,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -20079,8 +20105,8 @@
                 "enums": [
                     {
                         "items": [
-                            "usd",
-                            "implv"
+                            "implv",
+                            "usd"
                         ],
                         "name": "advanced"
                     }
@@ -20240,6 +20266,19 @@
                             "is_nested_array": false,
                             "is_primitive": true,
                             "name": "integer"
+                        }
+                    },
+                    {
+                        "comment": "Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.",
+                        "name": "display_amount",
+                        "required": "false",
+                        "type": {
+                            "enums": [],
+                            "fields": [],
+                            "is_array": false,
+                            "is_nested_array": false,
+                            "is_primitive": true,
+                            "name": "number"
                         }
                     }
                 ],
@@ -20438,6 +20477,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -20839,6 +20891,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -20966,19 +21031,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -21592,8 +21644,8 @@
                 "enums": [
                     {
                         "items": [
-                            "usd",
-                            "implv"
+                            "implv",
+                            "usd"
                         ],
                         "name": "advanced"
                     }
@@ -21951,6 +22003,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -22352,6 +22417,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -22479,19 +22557,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -23289,6 +23354,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -23679,6 +23757,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -23806,19 +23897,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -23954,6 +24032,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -24355,6 +24446,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -24482,19 +24586,6 @@
                         "is_nested_array": false,
                         "is_primitive": false,
                         "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
                     }
                 },
                 {
@@ -24730,34 +24821,34 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "trailing_stop",
-                            "trigger_all",
-                            "stop",
                             "all",
                             "limit",
-                            "take"
+                            "trailing_stop",
+                            "stop",
+                            "take",
+                            "trigger_all"
                         ],
                         "name": "type"
                     }
@@ -24954,73 +25045,73 @@
                 "enums": [
                     {
                         "items": [
-                            "eurr_usdt",
-                            "eth_eurr",
-                            "eth_usdc",
-                            "sol_usdt",
-                            "btcdvol_usdc",
-                            "usdc_usdt",
-                            "trump_usdc",
-                            "btc_usde",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "eth_usde",
-                            "eurr_usdc",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "eth_btc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "usyc_usdc",
-                            "btc_usyc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "steth_usdt",
-                            "usde_usdt",
-                            "paxg_btc",
-                            "steth_usdc",
-                            "link_usdc",
-                            "doge_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
-                            "eth_usyc",
                             "avax_usdc",
-                            "btc_usd",
-                            "shib_usdc",
-                            "btc_usdt",
-                            "eth_usdt",
+                            "paxg_btc",
+                            "btc_usyc",
+                            "algo_usdc",
+                            "dot_usdc",
                             "btc_eurr",
-                            "steth_eth",
+                            "eth_eurr",
+                            "eth_usde",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "eurr_usdt",
+                            "link_usdc",
+                            "btc_usde",
+                            "eth_usyc",
+                            "eth_btc",
+                            "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
+                            "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "usyc_usdc",
+                            "steth_usdc",
+                            "steth_usdt",
+                            "eth_usd",
+                            "eth_usdt",
+                            "ada_usdc",
+                            "sol_usdt",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "usdc_usdt",
+                            "usde_usdt",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "eurr_usdc",
+                            "bnb_usdc",
+                            "steth_eth",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "currency_pair"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "trailing_stop",
-                            "trigger_all",
-                            "stop",
                             "all",
                             "limit",
-                            "take"
+                            "trailing_stop",
+                            "stop",
+                            "take",
+                            "trigger_all"
                         ],
                         "name": "type"
                     }
@@ -25217,12 +25308,12 @@
                 "enums": [
                     {
                         "items": [
-                            "trailing_stop",
-                            "trigger_all",
-                            "stop",
                             "all",
                             "limit",
-                            "take"
+                            "trailing_stop",
+                            "stop",
+                            "take",
+                            "trigger_all"
                         ],
                         "name": "type"
                     }
@@ -25419,24 +25510,24 @@
                 "enums": [
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "trailing_stop",
-                            "trigger_all",
-                            "stop",
                             "all",
                             "limit",
-                            "take"
+                            "trailing_stop",
+                            "stop",
+                            "take",
+                            "trigger_all"
                         ],
                         "name": "type"
                     }
@@ -25633,11 +25724,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -25795,84 +25886,84 @@
                 "enums": [
                     {
                         "items": [
-                            "instrument_kind",
-                            "currency_pair",
-                            "currency",
-                            "instrument",
                             "quote_set_id",
+                            "all",
+                            "instrument",
                             "delta",
-                            "all"
+                            "currency",
+                            "currency_pair",
+                            "instrument_kind"
                         ],
                         "name": "cancel_type"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "eurr_usdt",
-                            "eth_eurr",
-                            "eth_usdc",
-                            "sol_usdt",
-                            "btcdvol_usdc",
-                            "usdc_usdt",
-                            "trump_usdc",
-                            "btc_usde",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "eth_usde",
-                            "eurr_usdc",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "eth_btc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "usyc_usdc",
-                            "btc_usyc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "steth_usdt",
-                            "usde_usdt",
-                            "paxg_btc",
-                            "steth_usdc",
-                            "link_usdc",
-                            "doge_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
-                            "eth_usyc",
                             "avax_usdc",
-                            "btc_usd",
-                            "shib_usdc",
-                            "btc_usdt",
-                            "eth_usdt",
+                            "paxg_btc",
+                            "btc_usyc",
+                            "algo_usdc",
+                            "dot_usdc",
                             "btc_eurr",
-                            "steth_eth",
+                            "eth_eurr",
+                            "eth_usde",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "eurr_usdt",
+                            "link_usdc",
+                            "btc_usde",
+                            "eth_usyc",
+                            "eth_btc",
+                            "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
+                            "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "usyc_usdc",
+                            "steth_usdc",
+                            "steth_usdt",
+                            "eth_usd",
+                            "eth_usdt",
+                            "ada_usdc",
+                            "sol_usdt",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "usdc_usdt",
+                            "usde_usdt",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "eurr_usdc",
+                            "bnb_usdc",
+                            "steth_eth",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "currency_pair"
                     }
@@ -26387,6 +26478,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -26777,6 +26881,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -26904,19 +27021,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -27808,34 +27912,34 @@
                 "enums": [
                     {
                         "items": [
-                            "eth_usdc",
-                            "btcdvol_usdc",
-                            "trump_usdc",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "all",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "doge_usdc",
-                            "link_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
                             "avax_usdc",
-                            "btc_usd",
+                            "all",
+                            "algo_usdc",
+                            "dot_usdc",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "link_usdc",
                             "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
                             "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "eth_usd",
                             "eth_usdt",
+                            "ada_usdc",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "bnb_usdc",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -28250,34 +28354,34 @@
                 "enums": [
                     {
                         "items": [
-                            "eth_usdc",
-                            "btcdvol_usdc",
-                            "trump_usdc",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "all",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "doge_usdc",
-                            "link_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
                             "avax_usdc",
-                            "btc_usd",
+                            "all",
+                            "algo_usdc",
+                            "dot_usdc",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "link_usdc",
                             "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
                             "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "eth_usd",
                             "eth_usdt",
+                            "ada_usdc",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "bnb_usdc",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -28562,27 +28666,27 @@
                 "enums": [
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "stop_market",
-                            "take_all",
-                            "trailing_stop",
-                            "trigger_all",
-                            "take_limit",
-                            "stop_all",
-                            "stop_limit",
-                            "take_market",
                             "all",
-                            "trailing_all",
-                            "limit"
+                            "stop_limit",
+                            "limit",
+                            "stop_all",
+                            "stop_market",
+                            "take_market",
+                            "trailing_stop",
+                            "take_limit",
+                            "trigger_all",
+                            "take_all",
+                            "trailing_all"
                         ],
                         "name": "type"
                     }
@@ -28775,6 +28879,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -29176,6 +29293,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -29303,19 +29433,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -29451,6 +29568,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -29852,6 +29982,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -29982,19 +30125,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -30076,37 +30206,37 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
                     {
                         "items": [
-                            "stop_market",
-                            "take_all",
-                            "trailing_stop",
-                            "trigger_all",
-                            "take_limit",
-                            "stop_all",
-                            "stop_limit",
-                            "take_market",
                             "all",
-                            "trailing_all",
-                            "limit"
+                            "stop_limit",
+                            "limit",
+                            "stop_all",
+                            "stop_market",
+                            "take_market",
+                            "trailing_stop",
+                            "take_limit",
+                            "trigger_all",
+                            "take_all",
+                            "trailing_all"
                         ],
                         "name": "type"
                     }
@@ -30323,6 +30453,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -30713,6 +30856,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -30840,19 +30996,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -30988,6 +31131,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -31389,6 +31545,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -31519,19 +31688,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -31613,17 +31769,17 @@
                 "enums": [
                     {
                         "items": [
-                            "stop_market",
-                            "take_all",
-                            "trailing_stop",
-                            "trigger_all",
-                            "take_limit",
-                            "stop_all",
-                            "stop_limit",
-                            "take_market",
                             "all",
-                            "trailing_all",
-                            "limit"
+                            "stop_limit",
+                            "limit",
+                            "stop_all",
+                            "stop_market",
+                            "take_market",
+                            "trailing_stop",
+                            "take_limit",
+                            "trigger_all",
+                            "take_all",
+                            "trailing_all"
                         ],
                         "name": "type"
                     }
@@ -31827,6 +31983,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -32217,6 +32386,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -32344,19 +32526,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -32492,6 +32661,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -32893,6 +33075,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -33023,19 +33218,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -33117,11 +33299,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -33325,6 +33507,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -33715,6 +33910,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -33842,19 +34050,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -33990,6 +34185,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -34391,6 +34599,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -34521,19 +34742,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -34615,23 +34823,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     }
@@ -34926,6 +35134,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -35316,6 +35537,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -35443,19 +35677,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -35591,6 +35812,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -35992,6 +36226,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -36119,19 +36366,6 @@
                         "is_nested_array": false,
                         "is_primitive": false,
                         "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
                     }
                 },
                 {
@@ -36491,6 +36725,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -36881,6 +37128,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -37008,19 +37268,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -37156,6 +37403,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -37557,6 +37817,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -37684,19 +37957,6 @@
                         "is_nested_array": false,
                         "is_primitive": false,
                         "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
                     }
                 },
                 {
@@ -38191,6 +38451,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -38581,6 +38854,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -38708,19 +38994,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -38856,6 +39129,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -39257,6 +39543,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -39387,19 +39686,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -39481,11 +39767,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -39689,6 +39975,19 @@
                             }
                         },
                         {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Option price in USD (Only if advanced=\"usd\")",
                             "name": "usd",
                             "required": false,
@@ -40079,6 +40378,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -40206,19 +40518,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -40354,6 +40653,19 @@
                 {
                     "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                     "name": "implv",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
+                    "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                    "name": "refresh_amount",
                     "required": false,
                     "type": {
                         "enums": [],
@@ -40755,6 +41067,19 @@
                     }
                 },
                 {
+                    "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                    "name": "display_amount",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "number"
+                    }
+                },
+                {
                     "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                     "name": "order_type",
                     "required": false,
@@ -40885,19 +41210,6 @@
                     }
                 },
                 {
-                    "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                    "name": "max_show",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
                     "comment": "It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.",
                     "name": "amount",
                     "required": false,
@@ -40979,11 +41291,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -41498,23 +41810,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
@@ -42336,23 +42648,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
-                            "future",
                             "any",
+                            "option",
+                            "future",
                             "future_combo",
                             "combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     },
@@ -45808,11 +46120,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -46159,34 +46471,34 @@
                 "enums": [
                     {
                         "items": [
-                            "eth_usdc",
-                            "btcdvol_usdc",
-                            "trump_usdc",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "all",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "doge_usdc",
-                            "link_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
                             "avax_usdc",
-                            "btc_usd",
+                            "all",
+                            "algo_usdc",
+                            "dot_usdc",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "link_usdc",
                             "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
                             "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "eth_usd",
                             "eth_usdt",
+                            "ada_usdc",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "bnb_usdc",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -46357,8 +46669,8 @@
                 "enums": [
                     {
                         "items": [
-                            "sell",
-                            "buy"
+                            "buy",
+                            "sell"
                         ],
                         "name": "side"
                     }
@@ -46529,34 +46841,34 @@
                 "enums": [
                     {
                         "items": [
-                            "eth_usdc",
-                            "btcdvol_usdc",
-                            "trump_usdc",
-                            "ethdvol_usdc",
-                            "algo_usdc",
-                            "all",
-                            "eth_usd",
-                            "paxg_usdc",
-                            "btc_usdc",
-                            "near_usdc",
-                            "uni_usdc",
-                            "ada_usdc",
-                            "xrp_usdc",
-                            "usde_usdc",
-                            "doge_usdc",
-                            "link_usdc",
-                            "sol_usdc",
-                            "bch_usdc",
-                            "bnb_usdc",
-                            "trx_usdc",
-                            "dot_usdc",
                             "avax_usdc",
-                            "btc_usd",
+                            "all",
+                            "algo_usdc",
+                            "dot_usdc",
+                            "paxg_usdc",
+                            "bch_usdc",
+                            "link_usdc",
                             "shib_usdc",
+                            "trx_usdc",
+                            "doge_usdc",
                             "btc_usdt",
+                            "uni_usdc",
+                            "eth_usdc",
+                            "eth_usd",
                             "eth_usdt",
+                            "ada_usdc",
+                            "ethdvol_usdc",
+                            "trump_usdc",
+                            "usde_usdc",
                             "ltc_usdc",
-                            "buidl_usdc"
+                            "sol_usdc",
+                            "xrp_usdc",
+                            "near_usdc",
+                            "buidl_usdc",
+                            "btc_usdc",
+                            "bnb_usdc",
+                            "btc_usd",
+                            "btcdvol_usdc"
                         ],
                         "name": "index_name"
                     }
@@ -47049,9 +47361,9 @@
                 "enums": [
                     {
                         "items": [
-                            "bankruptcy",
+                            "delivery",
                             "settlement",
-                            "delivery"
+                            "bankruptcy"
                         ],
                         "name": "type"
                     }
@@ -47501,19 +47813,19 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "bankruptcy",
+                            "delivery",
                             "settlement",
-                            "delivery"
+                            "bankruptcy"
                         ],
                         "name": "type"
                     }
@@ -48302,11 +48614,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
@@ -48472,12 +48784,12 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
                             "any",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -48830,8 +49142,8 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 }
@@ -49217,8 +49529,8 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 }
@@ -49532,8 +49844,8 @@
                 "enums": [
                     {
                         "items": [
-                            "taker",
-                            "maker"
+                            "maker",
+                            "taker"
                         ],
                         "name": "role"
                     }
@@ -49704,8 +50016,8 @@
                 "enums": [
                     {
                         "items": [
-                            "taker",
-                            "maker"
+                            "maker",
+                            "taker"
                         ],
                         "name": "role"
                     }
@@ -49758,8 +50070,8 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 }
@@ -51309,11 +51621,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -52718,8 +53030,8 @@
                 "enums": [
                     {
                         "items": [
-                            "taker",
-                            "maker"
+                            "maker",
+                            "taker"
                         ],
                         "name": "role"
                     }
@@ -52890,8 +53202,8 @@
                 "enums": [
                     {
                         "items": [
-                            "taker",
-                            "maker"
+                            "maker",
+                            "taker"
                         ],
                         "name": "role"
                     }
@@ -52918,8 +53230,8 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 }
@@ -53110,8 +53422,8 @@
                 "enums": [
                     {
                         "items": [
-                            "taker",
-                            "maker"
+                            "maker",
+                            "taker"
                         ],
                         "name": "role"
                     }
@@ -53164,8 +53476,8 @@
                             "enums": [
                                 {
                                     "items": [
-                                        "sell",
-                                        "buy"
+                                        "buy",
+                                        "sell"
                                     ],
                                     "name": "direction"
                                 }
@@ -53337,7 +53649,7 @@
                     "enums": [],
                     "fields": [
                         {
-                            "comment": "Signature of block trade It is valid only for 5 minutes \u201caround\u201d given timestamp",
+                            "comment": "Signature of block trade It is valid only for 5 minutes around given timestamp",
                             "name": "signature",
                             "required": false,
                             "type": {
@@ -53363,7 +53675,7 @@
             "enums": [],
             "fields": [
                 {
-                    "comment": "Signature of block trade It is valid only for 5 minutes \u201caround\u201d given timestamp",
+                    "comment": "Signature of block trade It is valid only for 5 minutes around given timestamp",
                     "name": "signature",
                     "required": false,
                     "type": {
@@ -53392,20 +53704,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     },
@@ -53498,6 +53810,19 @@
                         }
                     },
                     {
+                        "comment": "Website of the beneficiary VASP. Required if the address book entry is associated with a VASP that is not included in the list of known VASPs",
+                        "name": "beneficiary_vasp_website",
+                        "required": "false",
+                        "type": {
+                            "enums": [],
+                            "fields": [],
+                            "is_array": false,
+                            "is_nested_array": false,
+                            "is_primitive": true,
+                            "name": "string"
+                        }
+                    },
+                    {
                         "comment": "First name of beneficiary (if beneficiary is a person)",
                         "name": "beneficiary_first_name",
                         "required": "false",
@@ -53573,6 +53898,19 @@
                             "is_nested_array": false,
                             "is_primitive": true,
                             "name": "boolean"
+                        }
+                    },
+                    {
+                        "comment": "The user can pass a list of currencies to add the address for. It is currently available ONLY for ERC20 currencies. Without passing this paramater for an ERC20 currency, the address will be added to ALL of the ERC20 currencies.",
+                        "name": "extra_currencies",
+                        "required": "false",
+                        "type": {
+                            "enums": [],
+                            "fields": [],
+                            "is_array": true,
+                            "is_nested_array": false,
+                            "is_primitive": true,
+                            "name": "string"
                         }
                     }
                 ],
@@ -53775,6 +54113,19 @@
                         {
                             "comment": "Name of beneficiary VASP",
                             "name": "beneficiary_vasp_name",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Website of the beneficiary VASP",
+                            "name": "beneficiary_vasp_website",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -54033,6 +54384,19 @@
                     }
                 },
                 {
+                    "comment": "Website of the beneficiary VASP",
+                    "name": "beneficiary_vasp_website",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "string"
+                    }
+                },
+                {
                     "comment": "The timestamp (milliseconds since the Unix epoch)",
                     "name": "creation_timestamp",
                     "required": false,
@@ -54179,11 +54543,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -54585,11 +54949,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -55043,11 +55407,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -55306,20 +55670,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     },
@@ -55559,6 +55923,19 @@
                         {
                             "comment": "Name of beneficiary VASP",
                             "name": "beneficiary_vasp_name",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Website of the beneficiary VASP",
+                            "name": "beneficiary_vasp_website",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -55817,6 +56194,19 @@
                     }
                 },
                 {
+                    "comment": "Website of the beneficiary VASP",
+                    "name": "beneficiary_vasp_website",
+                    "required": false,
+                    "type": {
+                        "enums": [],
+                        "fields": [],
+                        "is_array": false,
+                        "is_nested_array": false,
+                        "is_primitive": false,
+                        "name": "string"
+                    }
+                },
+                {
                     "comment": "The timestamp (milliseconds since the Unix epoch)",
                     "name": "creation_timestamp",
                     "required": false,
@@ -55963,11 +56353,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -56226,11 +56616,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -56615,11 +57005,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -56978,11 +57368,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -57367,20 +57757,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     },
@@ -57559,11 +57949,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -57991,11 +58381,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -58410,11 +58800,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -58829,20 +59219,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     },
@@ -58912,6 +59302,19 @@
                         "comment": "DID of beneficiary VASP",
                         "name": "beneficiary_vasp_did",
                         "required": "true",
+                        "type": {
+                            "enums": [],
+                            "fields": [],
+                            "is_array": false,
+                            "is_nested_array": false,
+                            "is_primitive": true,
+                            "name": "string"
+                        }
+                    },
+                    {
+                        "comment": "Website of the beneficiary VASP. Required if the address book entry is associated with a VASP that is not included in the list of known VASPs",
+                        "name": "beneficiary_vasp_website",
+                        "required": "false",
                         "type": {
                             "enums": [],
                             "fields": [],
@@ -59138,23 +59541,23 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "extreme_high",
-                            "low",
                             "very_high",
                             "high",
+                            "low",
+                            "extreme_high",
                             "mid",
-                            "insane",
-                            "very_low"
+                            "very_low",
+                            "insane"
                         ],
                         "name": "priority"
                     }
@@ -60398,10 +60801,10 @@
                 "enums": [
                     {
                         "items": [
-                            "segregated_sm",
-                            "cross_sm",
                             "segregated_pm",
-                            "cross_pm"
+                            "cross_pm",
+                            "segregated_sm",
+                            "cross_sm"
                         ],
                         "name": "margin_model"
                     }
@@ -64575,45 +64978,6 @@
                                 "is_primitive": false,
                                 "name": "private_get_account_summaries_response_summary"
                             }
-                        },
-                        {
-                            "comment": "System generated user nickname (available when parameter extended = true)",
-                            "name": "system_name",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Account type (available when parameter extended = true)",
-                            "name": "type",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Account name (given by user) (available when parameter extended = true)",
-                            "name": "username",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
                         }
                     ],
                     "is_array": false,
@@ -64781,7 +65145,7 @@
                             }
                         },
                         {
-                            "comment": "User fees in case of any discounts (available when parameter extended = true and user has any discounts)",
+                            "comment": "List of fee objects for all currency pairs and instrument types related to the currency (available when parameter extended = true and user has any discounts)",
                             "name": "fees",
                             "required": false,
                             "type": {
@@ -64791,6 +65155,93 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "private_get_account_summaries_response_fee"
+                            }
+                        },
+                        {
+                            "comment": "System generated user nickname (available when parameter extended = true)",
+                            "name": "system_name",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Account type (available when parameter extended = true)",
+                            "name": "type",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Account name (given by user) (available when parameter extended = true)",
+                            "name": "username",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        }
+                    ],
+                    "is_array": true,
+                    "is_nested_array": false,
+                    "is_primitive": false,
+                    "name": "private_get_account_summaries_response_summary"
+                },
+                {
+                    "enums": [],
+                    "fields": [
+                        {
+                            "comment": "The currency pair this fee applies to",
+                            "name": "index_name",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Instrument type (e.g., future, perpetual, option)",
+                            "name": "kind",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "",
+                            "name": "value",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "private_get_account_summaries_response_value"
                             }
                         },
                         {
@@ -65213,53 +65664,14 @@
                     "is_array": true,
                     "is_nested_array": false,
                     "is_primitive": false,
-                    "name": "private_get_account_summaries_response_summary"
+                    "name": "private_get_account_summaries_response_fee"
                 },
                 {
                     "enums": [],
                     "fields": [
                         {
-                            "comment": "The currency the fee applies to",
-                            "name": "currency",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee",
-                            "name": "fee_type",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options",
-                            "name": "instrument_type",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "User fee as a maker",
-                            "name": "maker_fee",
+                            "comment": "Block trade fee (if applicable)",
+                            "name": "block_trade",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -65271,8 +65683,21 @@
                             }
                         },
                         {
-                            "comment": "User fee as a taker",
-                            "name": "taker_fee",
+                            "comment": "",
+                            "name": "default",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "private_get_account_summaries_response_default"
+                            }
+                        },
+                        {
+                            "comment": "Settlement fee",
+                            "name": "settlement",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -65284,10 +65709,58 @@
                             }
                         }
                     ],
-                    "is_array": true,
+                    "is_array": false,
                     "is_nested_array": false,
                     "is_primitive": false,
-                    "name": "private_get_account_summaries_response_fee"
+                    "name": "private_get_account_summaries_response_value"
+                },
+                {
+                    "enums": [],
+                    "fields": [
+                        {
+                            "comment": "Maker fee",
+                            "name": "maker",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "Taker fee",
+                            "name": "taker",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "Fee calculation type (e.g., fixed, relative)",
+                            "name": "type",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        }
+                    ],
+                    "is_array": false,
+                    "is_nested_array": false,
+                    "is_primitive": false,
+                    "name": "private_get_account_summaries_response_default"
                 }
             ]
         },
@@ -65451,45 +65924,6 @@
                         "is_primitive": false,
                         "name": "private_get_account_summaries_response_summary"
                     }
-                },
-                {
-                    "comment": "System generated user nickname (available when parameter extended = true)",
-                    "name": "system_name",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Account type (available when parameter extended = true)",
-                    "name": "type",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Account name (given by user) (available when parameter extended = true)",
-                    "name": "username",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
                 }
             ],
             "is_array": false,
@@ -65508,20 +65942,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     }
@@ -65842,7 +66276,7 @@
                             }
                         },
                         {
-                            "comment": "User fees in case of any discounts (available when parameter extended = true and user has any discounts)",
+                            "comment": "List of fee objects for all currency pairs and instrument types related to the currency (available when parameter extended = true and user has any discounts)",
                             "name": "fees",
                             "required": false,
                             "type": {
@@ -65852,6 +66286,54 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "private_get_account_summary_response_fee"
+                            }
+                        }
+                    ],
+                    "is_array": false,
+                    "is_nested_array": false,
+                    "is_primitive": false,
+                    "name": "private_get_account_summary_response_result"
+                },
+                {
+                    "enums": [],
+                    "fields": [
+                        {
+                            "comment": "The currency pair this fee applies to",
+                            "name": "index_name",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options",
+                            "name": "kind",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        },
+                        {
+                            "comment": "",
+                            "name": "value",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "private_get_account_summary_response_value"
                             }
                         },
                         {
@@ -66427,56 +66909,17 @@
                             }
                         }
                     ],
-                    "is_array": false,
+                    "is_array": true,
                     "is_nested_array": false,
                     "is_primitive": false,
-                    "name": "private_get_account_summary_response_result"
+                    "name": "private_get_account_summary_response_fee"
                 },
                 {
                     "enums": [],
                     "fields": [
                         {
-                            "comment": "The currency the fee applies to",
-                            "name": "currency",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee",
-                            "name": "fee_type",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options",
-                            "name": "instrument_type",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "string"
-                            }
-                        },
-                        {
-                            "comment": "User fee as a maker",
-                            "name": "maker_fee",
+                            "comment": "Block trade fee (if applicable)",
+                            "name": "block_trade",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -66488,8 +66931,21 @@
                             }
                         },
                         {
-                            "comment": "User fee as a taker",
-                            "name": "taker_fee",
+                            "comment": "",
+                            "name": "default",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "private_get_account_summary_response_default"
+                            }
+                        },
+                        {
+                            "comment": "Settlement fee",
+                            "name": "settlement",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -66501,10 +66957,58 @@
                             }
                         }
                     ],
-                    "is_array": true,
+                    "is_array": false,
                     "is_nested_array": false,
                     "is_primitive": false,
-                    "name": "private_get_account_summary_response_fee"
+                    "name": "private_get_account_summary_response_value"
+                },
+                {
+                    "enums": [],
+                    "fields": [
+                        {
+                            "comment": "Maker fee",
+                            "name": "maker",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "Taker fee",
+                            "name": "taker",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee",
+                            "name": "type",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "string"
+                            }
+                        }
+                    ],
+                    "is_array": false,
+                    "is_nested_array": false,
+                    "is_primitive": false,
+                    "name": "private_get_account_summary_response_default"
                 }
             ]
         },
@@ -66683,7 +67187,7 @@
                     }
                 },
                 {
-                    "comment": "User fees in case of any discounts (available when parameter extended = true and user has any discounts)",
+                    "comment": "List of fee objects for all currency pairs and instrument types related to the currency (available when parameter extended = true and user has any discounts)",
                     "name": "fees",
                     "required": false,
                     "type": {
@@ -66693,578 +67197,6 @@
                         "is_nested_array": false,
                         "is_primitive": false,
                         "name": "private_get_account_summary_response_fee"
-                    }
-                },
-                {
-                    "comment": "The account's balance reserved in other orders",
-                    "name": "additional_reserve",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Options session unrealized profit and Loss",
-                    "name": "options_session_upl",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "When true cross collateral is enabled for user",
-                    "name": "cross_collateral_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Account id (available when parameter extended = true)",
-                    "name": "id",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "integer"
-                    }
-                },
-                {
-                    "comment": "Options value",
-                    "name": "options_value",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Time at which the account was created (milliseconds since the Unix epoch; available when parameter extended = true)",
-                    "name": "creation_timestamp",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "integer"
-                    }
-                },
-                {
-                    "comment": "User email (available when parameter extended = true)",
-                    "name": "email",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Map of options' vegas per index",
-                    "name": "options_vega_map",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "json"
-                    }
-                },
-                {
-                    "comment": "The maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "maintenance_margin",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Whether MMP is enabled (available when parameter extended = true)",
-                    "name": "mmp_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Futures session unrealized profit and Loss",
-                    "name": "futures_session_upl",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "true when portfolio margining is enabled for user",
-                    "name": "portfolio_margining_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Futures profit and Loss",
-                    "name": "futures_pl",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Map of options' gammas per index",
-                    "name": "options_gamma_map",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "json"
-                    }
-                },
-                {
-                    "comment": "The selected currency",
-                    "name": "currency",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Options summary delta",
-                    "name": "options_delta",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "The account's initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "initial_margin",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Projected maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "projected_maintenance_margin",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "The account's available funds. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "available_funds",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Optional identifier of the referrer (of the affiliation program, and available when parameter extended = true), which link was used by this account at registration. It coincides with suffix of the affiliation link path after /reg-",
-                    "name": "referrer_id",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Whether account is loginable using email and password (available when parameter extended = true and account is a subaccount)",
-                    "name": "login_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "The account's current equity",
-                    "name": "equity",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Name of user's currently enabled margin model",
-                    "name": "margin_model",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "The account's balance",
-                    "name": "balance",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Session unrealized profit and loss",
-                    "name": "session_upl",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "The account's margin balance. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "margin_balance",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Whether Security Key authentication is enabled (available when parameter extended = true)",
-                    "name": "security_keys_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "The deposit address for the account (if available)",
-                    "name": "deposit_address",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Options summary theta",
-                    "name": "options_theta",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "true if self trading rejection behavior is applied to trades between subaccounts (available when parameter extended = true)",
-                    "name": "self_trading_extended_to_subaccounts",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "true when the inter-user transfers are enabled for user (available when parameter extended = true)",
-                    "name": "interuser_transfers_enabled",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "comment": "Optional (only for users using cross margin). The account's total initial margin in all cross collateral currencies, expressed in USD",
-                    "name": "total_initial_margin_usd",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Estimated Liquidation Ratio is returned only for users without portfolio margining enabled. Multiplying it by future position's market price returns its estimated liquidation price. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "estimated_liquidation_ratio",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Session realized profit and loss",
-                    "name": "session_rpl",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "The account's fee balance (it can be used to pay for fees)",
-                    "name": "fee_balance",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Optional (only for users using cross margin). The account's total maintenance margin in all cross collateral currencies, expressed in USD",
-                    "name": "total_maintenance_margin_usd",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Options summary vega",
-                    "name": "options_vega",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Projected initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency's value to the given currency, using each cross collateral currency's index.",
-                    "name": "projected_initial_margin",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Self trading rejection behavior - reject_taker or cancel_maker (available when parameter extended = true)",
-                    "name": "self_trading_reject_mode",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "System generated user nickname (available when parameter extended = true)",
-                    "name": "system_name",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Options summary gamma",
-                    "name": "options_gamma",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "Account name (given by user) (available when parameter extended = true)",
-                    "name": "username",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "string"
-                    }
-                },
-                {
-                    "comment": "Optional (only for users using cross margin). The account's total equity in all cross collateral currencies, expressed in USD",
-                    "name": "total_equity_usd",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
-                    }
-                },
-                {
-                    "comment": "The sum of position deltas",
-                    "name": "delta_total",
-                    "required": false,
-                    "type": {
-                        "enums": [],
-                        "fields": [],
-                        "is_array": false,
-                        "is_nested_array": false,
-                        "is_primitive": false,
-                        "name": "number"
                     }
                 }
             ],
@@ -68748,22 +68680,22 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
                             "any",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     },
                     {
                         "items": [
-                            "option_combo",
                             "spot",
+                            "option",
                             "future",
                             "future_combo",
-                            "option"
+                            "option_combo"
                         ],
                         "name": "kind"
                     }
@@ -70341,11 +70273,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -70586,6 +70518,19 @@
                         {
                             "comment": "Implied volatility in percent. (Only if advanced=\"implv\")",
                             "name": "implv",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
+                            "comment": "The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders",
+                            "name": "refresh_amount",
                             "required": false,
                             "type": {
                                 "enums": [],
@@ -70987,6 +70932,19 @@
                             }
                         },
                         {
+                            "comment": "The actual display amount of iceberg order. Absent for other types of orders.",
+                            "name": "display_amount",
+                            "required": false,
+                            "type": {
+                                "enums": [],
+                                "fields": [],
+                                "is_array": false,
+                                "is_nested_array": false,
+                                "is_primitive": false,
+                                "name": "number"
+                            }
+                        },
+                        {
                             "comment": "Order type: \"limit\", \"market\", \"stop_limit\", \"stop_market\"",
                             "name": "order_type",
                             "required": false,
@@ -71114,19 +71072,6 @@
                                 "is_nested_array": false,
                                 "is_primitive": false,
                                 "name": "boolean"
-                            }
-                        },
-                        {
-                            "comment": "Maximum amount within an order to be shown to other traders, 0 for invisible order.",
-                            "name": "max_show",
-                            "required": false,
-                            "type": {
-                                "enums": [],
-                                "fields": [],
-                                "is_array": false,
-                                "is_nested_array": false,
-                                "is_primitive": false,
-                                "name": "number"
                             }
                         },
                         {
@@ -71571,20 +71516,20 @@
                 "enums": [
                     {
                         "items": [
-                            "USDE",
-                            "USDT",
                             "XRP",
-                            "PAXG",
-                            "BNB",
-                            "ETH",
-                            "SOL",
-                            "STETH",
-                            "EURR",
-                            "ETHW",
                             "MATIC",
-                            "BTC",
+                            "ETHW",
+                            "STETH",
+                            "ETH",
+                            "USDE",
                             "USDC",
-                            "USYC"
+                            "USYC",
+                            "BNB",
+                            "PAXG",
+                            "EURR",
+                            "USDT",
+                            "BTC",
+                            "SOL"
                         ],
                         "name": "currency"
                     }
@@ -72925,11 +72870,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -73370,11 +73315,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
+                            "CROSS",
                             "ETH",
-                            "BTC",
                             "USDC",
-                            "CROSS"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -75005,11 +74950,11 @@
                 "enums": [
                     {
                         "items": [
-                            "USDT",
                             "ETH",
+                            "USDC",
                             "EURR",
-                            "BTC",
-                            "USDC"
+                            "USDT",
+                            "BTC"
                         ],
                         "name": "currency"
                     }
@@ -75331,8 +75276,8 @@
                 "enums": [
                     {
                         "items": [
-                            "disable",
-                            "enable"
+                            "enable",
+                            "disable"
                         ],
                         "name": "state"
                     }

--- a/sql/endpoints/private_cancel.sql
+++ b/sql/endpoints/private_cancel.sql
@@ -23,6 +23,7 @@ create type deribit.private_cancel_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -53,6 +54,7 @@ create type deribit.private_cancel_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -63,7 +65,6 @@ create type deribit.private_cancel_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -76,6 +77,7 @@ comment on column deribit.private_cancel_response_result."triggered" is 'Whether
 comment on column deribit.private_cancel_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_cancel_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_cancel_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_cancel_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_cancel_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_cancel_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_cancel_response_result."api" is 'true if created with API';
@@ -106,6 +108,7 @@ comment on column deribit.private_cancel_response_result."price" is 'Price in ba
 comment on column deribit.private_cancel_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_cancel_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_cancel_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_cancel_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_cancel_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_cancel_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_cancel_response_result."original_order_type" is 'Original order type. Optional field';
@@ -116,7 +119,6 @@ comment on column deribit.private_cancel_response_result."trigger_offset" is 'Th
 comment on column deribit.private_cancel_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_cancel_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_cancel_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_cancel_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_cancel_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_cancel_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_cancel_response_result."instrument_name" is 'Unique instrument identifier';

--- a/sql/endpoints/private_close_position.sql
+++ b/sql/endpoints/private_close_position.sql
@@ -110,6 +110,7 @@ create type deribit.private_close_position_response_order as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -140,6 +141,7 @@ create type deribit.private_close_position_response_order as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -150,7 +152,6 @@ create type deribit.private_close_position_response_order as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -163,6 +164,7 @@ comment on column deribit.private_close_position_response_order."triggered" is '
 comment on column deribit.private_close_position_response_order."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_close_position_response_order."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_close_position_response_order."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_close_position_response_order."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_close_position_response_order."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_close_position_response_order."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_close_position_response_order."api" is 'true if created with API';
@@ -193,6 +195,7 @@ comment on column deribit.private_close_position_response_order."price" is 'Pric
 comment on column deribit.private_close_position_response_order."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_close_position_response_order."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_close_position_response_order."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_close_position_response_order."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_close_position_response_order."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_close_position_response_order."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_close_position_response_order."original_order_type" is 'Original order type. Optional field';
@@ -203,7 +206,6 @@ comment on column deribit.private_close_position_response_order."trigger_offset"
 comment on column deribit.private_close_position_response_order."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_close_position_response_order."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_close_position_response_order."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_close_position_response_order."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_close_position_response_order."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_close_position_response_order."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_close_position_response_order."instrument_name" is 'Unique instrument identifier';

--- a/sql/endpoints/private_edit_by_label.sql
+++ b/sql/endpoints/private_edit_by_label.sql
@@ -128,6 +128,7 @@ create type deribit.private_edit_by_label_response_order as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -158,6 +159,7 @@ create type deribit.private_edit_by_label_response_order as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -168,7 +170,6 @@ create type deribit.private_edit_by_label_response_order as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -181,6 +182,7 @@ comment on column deribit.private_edit_by_label_response_order."triggered" is 'W
 comment on column deribit.private_edit_by_label_response_order."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_edit_by_label_response_order."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_edit_by_label_response_order."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_edit_by_label_response_order."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_edit_by_label_response_order."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_edit_by_label_response_order."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_edit_by_label_response_order."api" is 'true if created with API';
@@ -211,6 +213,7 @@ comment on column deribit.private_edit_by_label_response_order."price" is 'Price
 comment on column deribit.private_edit_by_label_response_order."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_edit_by_label_response_order."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_edit_by_label_response_order."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_edit_by_label_response_order."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_edit_by_label_response_order."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_edit_by_label_response_order."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_edit_by_label_response_order."original_order_type" is 'Original order type. Optional field';
@@ -221,7 +224,6 @@ comment on column deribit.private_edit_by_label_response_order."trigger_offset" 
 comment on column deribit.private_edit_by_label_response_order."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_edit_by_label_response_order."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_edit_by_label_response_order."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_edit_by_label_response_order."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_edit_by_label_response_order."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_edit_by_label_response_order."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_edit_by_label_response_order."instrument_name" is 'Unique instrument identifier';

--- a/sql/endpoints/private_get_account_summaries.sql
+++ b/sql/endpoints/private_get_account_summaries.sql
@@ -19,34 +19,29 @@ create type deribit.private_get_account_summaries_request as (
 comment on column deribit.private_get_account_summaries_request."subaccount_id" is 'The user id for the subaccount';
 comment on column deribit.private_get_account_summaries_request."extended" is 'Include additional fields';
 
-create type deribit.private_get_account_summaries_response_fee as (
-    "currency" text,
-    "fee_type" text,
-    "instrument_type" text,
-    "maker_fee" double precision,
-    "taker_fee" double precision
+create type deribit.private_get_account_summaries_response_default as (
+    "maker" double precision,
+    "taker" double precision,
+    "type" text
 );
 
-comment on column deribit.private_get_account_summaries_response_fee."currency" is 'The currency the fee applies to';
-comment on column deribit.private_get_account_summaries_response_fee."fee_type" is 'Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee';
-comment on column deribit.private_get_account_summaries_response_fee."instrument_type" is 'Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options';
-comment on column deribit.private_get_account_summaries_response_fee."maker_fee" is 'User fee as a maker';
-comment on column deribit.private_get_account_summaries_response_fee."taker_fee" is 'User fee as a taker';
+comment on column deribit.private_get_account_summaries_response_default."maker" is 'Maker fee';
+comment on column deribit.private_get_account_summaries_response_default."taker" is 'Taker fee';
+comment on column deribit.private_get_account_summaries_response_default."type" is 'Fee calculation type (e.g., fixed, relative)';
 
-create type deribit.private_get_account_summaries_response_summary as (
-    "options_pl" double precision,
-    "projected_delta_total" double precision,
-    "options_theta_map" jsonb,
-    "has_non_block_chain_equity" boolean,
-    "total_margin_balance_usd" double precision,
-    "limits" jsonb,
-    "total_delta_total_usd" double precision,
-    "available_withdrawal_funds" double precision,
-    "options_session_rpl" double precision,
-    "futures_session_rpl" double precision,
-    "total_pl" double precision,
-    "spot_reserve" double precision,
-    "fees" deribit.private_get_account_summaries_response_fee[],
+create type deribit.private_get_account_summaries_response_value as (
+    "block_trade" double precision,
+    "default" deribit.private_get_account_summaries_response_default,
+    "settlement" double precision
+);
+
+comment on column deribit.private_get_account_summaries_response_value."block_trade" is 'Block trade fee (if applicable)';
+comment on column deribit.private_get_account_summaries_response_value."settlement" is 'Settlement fee';
+
+create type deribit.private_get_account_summaries_response_fee as (
+    "index_name" text,
+    "kind" text,
+    "value" deribit.private_get_account_summaries_response_value,
     "additional_reserve" double precision,
     "options_session_upl" double precision,
     "cross_collateral_enabled" boolean,
@@ -81,6 +76,60 @@ create type deribit.private_get_account_summaries_response_summary as (
     "delta_total" double precision
 );
 
+comment on column deribit.private_get_account_summaries_response_fee."index_name" is 'The currency pair this fee applies to';
+comment on column deribit.private_get_account_summaries_response_fee."kind" is 'Instrument type (e.g., future, perpetual, option)';
+comment on column deribit.private_get_account_summaries_response_fee."additional_reserve" is 'The account''s balance reserved in other orders';
+comment on column deribit.private_get_account_summaries_response_fee."options_session_upl" is 'Options session unrealized profit and Loss';
+comment on column deribit.private_get_account_summaries_response_fee."cross_collateral_enabled" is 'When true cross collateral is enabled for user';
+comment on column deribit.private_get_account_summaries_response_fee."options_value" is 'Options value';
+comment on column deribit.private_get_account_summaries_response_fee."options_vega_map" is 'Map of options'' vegas per index';
+comment on column deribit.private_get_account_summaries_response_fee."maintenance_margin" is 'The maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."futures_session_upl" is 'Futures session unrealized profit and Loss';
+comment on column deribit.private_get_account_summaries_response_fee."portfolio_margining_enabled" is 'true when portfolio margining is enabled for user';
+comment on column deribit.private_get_account_summaries_response_fee."futures_pl" is 'Futures profit and Loss';
+comment on column deribit.private_get_account_summaries_response_fee."options_gamma_map" is 'Map of options'' gammas per index';
+comment on column deribit.private_get_account_summaries_response_fee."currency" is 'Currency of the summary';
+comment on column deribit.private_get_account_summaries_response_fee."options_delta" is 'Options summary delta';
+comment on column deribit.private_get_account_summaries_response_fee."initial_margin" is 'The account''s initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."projected_maintenance_margin" is 'Projected maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."available_funds" is 'The account''s available funds. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."equity" is 'The account''s current equity';
+comment on column deribit.private_get_account_summaries_response_fee."margin_model" is 'Name of user''s currently enabled margin model';
+comment on column deribit.private_get_account_summaries_response_fee."balance" is 'The account''s balance';
+comment on column deribit.private_get_account_summaries_response_fee."session_upl" is 'Session unrealized profit and loss';
+comment on column deribit.private_get_account_summaries_response_fee."margin_balance" is 'The account''s margin balance. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."deposit_address" is 'The deposit address for the account (if available)';
+comment on column deribit.private_get_account_summaries_response_fee."options_theta" is 'Options summary theta';
+comment on column deribit.private_get_account_summaries_response_fee."total_initial_margin_usd" is 'Optional (only for users using cross margin). The account''s total initial margin in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summaries_response_fee."estimated_liquidation_ratio" is 'Estimated Liquidation Ratio is returned only for users without portfolio margining enabled. Multiplying it by future position''s market price returns its estimated liquidation price. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."session_rpl" is 'Session realized profit and loss';
+comment on column deribit.private_get_account_summaries_response_fee."fee_balance" is 'The account''s fee balance (it can be used to pay for fees)';
+comment on column deribit.private_get_account_summaries_response_fee."total_maintenance_margin_usd" is 'Optional (only for users using cross margin). The account''s total maintenance margin in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summaries_response_fee."options_vega" is 'Options summary vega';
+comment on column deribit.private_get_account_summaries_response_fee."projected_initial_margin" is 'Projected initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summaries_response_fee."options_gamma" is 'Options summary gamma';
+comment on column deribit.private_get_account_summaries_response_fee."total_equity_usd" is 'Optional (only for users using cross margin). The account''s total equity in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summaries_response_fee."delta_total" is 'The sum of position deltas';
+
+create type deribit.private_get_account_summaries_response_summary as (
+    "options_pl" double precision,
+    "projected_delta_total" double precision,
+    "options_theta_map" jsonb,
+    "has_non_block_chain_equity" boolean,
+    "total_margin_balance_usd" double precision,
+    "limits" jsonb,
+    "total_delta_total_usd" double precision,
+    "available_withdrawal_funds" double precision,
+    "options_session_rpl" double precision,
+    "futures_session_rpl" double precision,
+    "total_pl" double precision,
+    "spot_reserve" double precision,
+    "fees" deribit.private_get_account_summaries_response_fee[],
+    "system_name" text,
+    "type" text,
+    "username" text
+);
+
 comment on column deribit.private_get_account_summaries_response_summary."options_pl" is 'Options profit and Loss';
 comment on column deribit.private_get_account_summaries_response_summary."projected_delta_total" is 'The sum of position deltas without positions that will expire during closest expiration';
 comment on column deribit.private_get_account_summaries_response_summary."options_theta_map" is 'Map of options'' thetas per index';
@@ -93,39 +142,10 @@ comment on column deribit.private_get_account_summaries_response_summary."option
 comment on column deribit.private_get_account_summaries_response_summary."futures_session_rpl" is 'Futures session realized profit and Loss';
 comment on column deribit.private_get_account_summaries_response_summary."total_pl" is 'Profit and loss';
 comment on column deribit.private_get_account_summaries_response_summary."spot_reserve" is 'The account''s balance reserved in active spot orders';
-comment on column deribit.private_get_account_summaries_response_summary."fees" is 'User fees in case of any discounts (available when parameter extended = true and user has any discounts)';
-comment on column deribit.private_get_account_summaries_response_summary."additional_reserve" is 'The account''s balance reserved in other orders';
-comment on column deribit.private_get_account_summaries_response_summary."options_session_upl" is 'Options session unrealized profit and Loss';
-comment on column deribit.private_get_account_summaries_response_summary."cross_collateral_enabled" is 'When true cross collateral is enabled for user';
-comment on column deribit.private_get_account_summaries_response_summary."options_value" is 'Options value';
-comment on column deribit.private_get_account_summaries_response_summary."options_vega_map" is 'Map of options'' vegas per index';
-comment on column deribit.private_get_account_summaries_response_summary."maintenance_margin" is 'The maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."futures_session_upl" is 'Futures session unrealized profit and Loss';
-comment on column deribit.private_get_account_summaries_response_summary."portfolio_margining_enabled" is 'true when portfolio margining is enabled for user';
-comment on column deribit.private_get_account_summaries_response_summary."futures_pl" is 'Futures profit and Loss';
-comment on column deribit.private_get_account_summaries_response_summary."options_gamma_map" is 'Map of options'' gammas per index';
-comment on column deribit.private_get_account_summaries_response_summary."currency" is 'Currency of the summary';
-comment on column deribit.private_get_account_summaries_response_summary."options_delta" is 'Options summary delta';
-comment on column deribit.private_get_account_summaries_response_summary."initial_margin" is 'The account''s initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."projected_maintenance_margin" is 'Projected maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."available_funds" is 'The account''s available funds. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."equity" is 'The account''s current equity';
-comment on column deribit.private_get_account_summaries_response_summary."margin_model" is 'Name of user''s currently enabled margin model';
-comment on column deribit.private_get_account_summaries_response_summary."balance" is 'The account''s balance';
-comment on column deribit.private_get_account_summaries_response_summary."session_upl" is 'Session unrealized profit and loss';
-comment on column deribit.private_get_account_summaries_response_summary."margin_balance" is 'The account''s margin balance. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."deposit_address" is 'The deposit address for the account (if available)';
-comment on column deribit.private_get_account_summaries_response_summary."options_theta" is 'Options summary theta';
-comment on column deribit.private_get_account_summaries_response_summary."total_initial_margin_usd" is 'Optional (only for users using cross margin). The account''s total initial margin in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summaries_response_summary."estimated_liquidation_ratio" is 'Estimated Liquidation Ratio is returned only for users without portfolio margining enabled. Multiplying it by future position''s market price returns its estimated liquidation price. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."session_rpl" is 'Session realized profit and loss';
-comment on column deribit.private_get_account_summaries_response_summary."fee_balance" is 'The account''s fee balance (it can be used to pay for fees)';
-comment on column deribit.private_get_account_summaries_response_summary."total_maintenance_margin_usd" is 'Optional (only for users using cross margin). The account''s total maintenance margin in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summaries_response_summary."options_vega" is 'Options summary vega';
-comment on column deribit.private_get_account_summaries_response_summary."projected_initial_margin" is 'Projected initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summaries_response_summary."options_gamma" is 'Options summary gamma';
-comment on column deribit.private_get_account_summaries_response_summary."total_equity_usd" is 'Optional (only for users using cross margin). The account''s total equity in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summaries_response_summary."delta_total" is 'The sum of position deltas';
+comment on column deribit.private_get_account_summaries_response_summary."fees" is 'List of fee objects for all currency pairs and instrument types related to the currency (available when parameter extended = true and user has any discounts)';
+comment on column deribit.private_get_account_summaries_response_summary."system_name" is 'System generated user nickname (available when parameter extended = true)';
+comment on column deribit.private_get_account_summaries_response_summary."type" is 'Account type (available when parameter extended = true)';
+comment on column deribit.private_get_account_summaries_response_summary."username" is 'Account name (given by user) (available when parameter extended = true)';
 
 create type deribit.private_get_account_summaries_response_result as (
     "block_rfq_self_match_prevention" text,
@@ -139,10 +159,7 @@ create type deribit.private_get_account_summaries_response_result as (
     "security_keys_enabled" boolean,
     "self_trading_extended_to_subaccounts" text,
     "self_trading_reject_mode" text,
-    "summaries" deribit.private_get_account_summaries_response_summary[],
-    "system_name" text,
-    "type" text,
-    "username" text
+    "summaries" deribit.private_get_account_summaries_response_summary[]
 );
 
 comment on column deribit.private_get_account_summaries_response_result."block_rfq_self_match_prevention" is 'When Block RFQ Self Match Prevention is enabled, it ensures that RFQs cannot be executed between accounts that belong to the same legal entity. This setting is independent of the general self-match prevention settings and must be configured separately.';
@@ -157,9 +174,6 @@ comment on column deribit.private_get_account_summaries_response_result."securit
 comment on column deribit.private_get_account_summaries_response_result."self_trading_extended_to_subaccounts" is 'true if self trading rejection behavior is applied to trades between subaccounts (available when parameter extended = true)';
 comment on column deribit.private_get_account_summaries_response_result."self_trading_reject_mode" is 'Self trading rejection behavior - reject_taker or cancel_maker (available when parameter extended = true)';
 comment on column deribit.private_get_account_summaries_response_result."summaries" is 'Aggregated list of per-currency account summaries';
-comment on column deribit.private_get_account_summaries_response_result."system_name" is 'System generated user nickname (available when parameter extended = true)';
-comment on column deribit.private_get_account_summaries_response_result."type" is 'Account type (available when parameter extended = true)';
-comment on column deribit.private_get_account_summaries_response_result."username" is 'Account name (given by user) (available when parameter extended = true)';
 
 create type deribit.private_get_account_summaries_response as (
     "id" bigint,

--- a/sql/endpoints/private_get_account_summary.sql
+++ b/sql/endpoints/private_get_account_summary.sql
@@ -38,35 +38,29 @@ comment on column deribit.private_get_account_summary_request."currency" is '(Re
 comment on column deribit.private_get_account_summary_request."subaccount_id" is 'The user id for the subaccount';
 comment on column deribit.private_get_account_summary_request."extended" is 'Include additional fields';
 
-create type deribit.private_get_account_summary_response_fee as (
-    "currency" text,
-    "fee_type" text,
-    "instrument_type" text,
-    "maker_fee" double precision,
-    "taker_fee" double precision
+create type deribit.private_get_account_summary_response_default as (
+    "maker" double precision,
+    "taker" double precision,
+    "type" text
 );
 
-comment on column deribit.private_get_account_summary_response_fee."currency" is 'The currency the fee applies to';
-comment on column deribit.private_get_account_summary_response_fee."fee_type" is 'Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee';
-comment on column deribit.private_get_account_summary_response_fee."instrument_type" is 'Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options';
-comment on column deribit.private_get_account_summary_response_fee."maker_fee" is 'User fee as a maker';
-comment on column deribit.private_get_account_summary_response_fee."taker_fee" is 'User fee as a taker';
+comment on column deribit.private_get_account_summary_response_default."maker" is 'Maker fee';
+comment on column deribit.private_get_account_summary_response_default."taker" is 'Taker fee';
+comment on column deribit.private_get_account_summary_response_default."type" is 'Fee type - relative if fee is calculated as a fraction of base instrument fee, fixed if fee is calculated solely using user fee';
 
-create type deribit.private_get_account_summary_response_result as (
-    "options_pl" double precision,
-    "projected_delta_total" double precision,
-    "options_theta_map" jsonb,
-    "has_non_block_chain_equity" boolean,
-    "total_margin_balance_usd" double precision,
-    "limits" jsonb,
-    "type" text,
-    "total_delta_total_usd" double precision,
-    "available_withdrawal_funds" double precision,
-    "options_session_rpl" double precision,
-    "futures_session_rpl" double precision,
-    "total_pl" double precision,
-    "spot_reserve" double precision,
-    "fees" deribit.private_get_account_summary_response_fee[],
+create type deribit.private_get_account_summary_response_value as (
+    "block_trade" double precision,
+    "default" deribit.private_get_account_summary_response_default,
+    "settlement" double precision
+);
+
+comment on column deribit.private_get_account_summary_response_value."block_trade" is 'Block trade fee (if applicable)';
+comment on column deribit.private_get_account_summary_response_value."settlement" is 'Settlement fee';
+
+create type deribit.private_get_account_summary_response_fee as (
+    "index_name" text,
+    "kind" text,
+    "value" deribit.private_get_account_summary_response_value,
     "additional_reserve" double precision,
     "options_session_upl" double precision,
     "cross_collateral_enabled" boolean,
@@ -113,6 +107,70 @@ create type deribit.private_get_account_summary_response_result as (
     "delta_total" double precision
 );
 
+comment on column deribit.private_get_account_summary_response_fee."index_name" is 'The currency pair this fee applies to';
+comment on column deribit.private_get_account_summary_response_fee."kind" is 'Type of the instruments the fee applies to - future for future instruments (excluding perpetual), perpetual for future perpetual instruments, option for options';
+comment on column deribit.private_get_account_summary_response_fee."additional_reserve" is 'The account''s balance reserved in other orders';
+comment on column deribit.private_get_account_summary_response_fee."options_session_upl" is 'Options session unrealized profit and Loss';
+comment on column deribit.private_get_account_summary_response_fee."cross_collateral_enabled" is 'When true cross collateral is enabled for user';
+comment on column deribit.private_get_account_summary_response_fee."id" is 'Account id (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."options_value" is 'Options value';
+comment on column deribit.private_get_account_summary_response_fee."creation_timestamp" is 'Time at which the account was created (milliseconds since the Unix epoch; available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."email" is 'User email (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."options_vega_map" is 'Map of options'' vegas per index';
+comment on column deribit.private_get_account_summary_response_fee."maintenance_margin" is 'The maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."mmp_enabled" is 'Whether MMP is enabled (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."futures_session_upl" is 'Futures session unrealized profit and Loss';
+comment on column deribit.private_get_account_summary_response_fee."portfolio_margining_enabled" is 'true when portfolio margining is enabled for user';
+comment on column deribit.private_get_account_summary_response_fee."futures_pl" is 'Futures profit and Loss';
+comment on column deribit.private_get_account_summary_response_fee."options_gamma_map" is 'Map of options'' gammas per index';
+comment on column deribit.private_get_account_summary_response_fee."currency" is 'The selected currency';
+comment on column deribit.private_get_account_summary_response_fee."options_delta" is 'Options summary delta';
+comment on column deribit.private_get_account_summary_response_fee."initial_margin" is 'The account''s initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."projected_maintenance_margin" is 'Projected maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."available_funds" is 'The account''s available funds. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."referrer_id" is 'Optional identifier of the referrer (of the affiliation program, and available when parameter extended = true), which link was used by this account at registration. It coincides with suffix of the affiliation link path after /reg-';
+comment on column deribit.private_get_account_summary_response_fee."login_enabled" is 'Whether account is loginable using email and password (available when parameter extended = true and account is a subaccount)';
+comment on column deribit.private_get_account_summary_response_fee."equity" is 'The account''s current equity';
+comment on column deribit.private_get_account_summary_response_fee."margin_model" is 'Name of user''s currently enabled margin model';
+comment on column deribit.private_get_account_summary_response_fee."balance" is 'The account''s balance';
+comment on column deribit.private_get_account_summary_response_fee."session_upl" is 'Session unrealized profit and loss';
+comment on column deribit.private_get_account_summary_response_fee."margin_balance" is 'The account''s margin balance. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."security_keys_enabled" is 'Whether Security Key authentication is enabled (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."deposit_address" is 'The deposit address for the account (if available)';
+comment on column deribit.private_get_account_summary_response_fee."options_theta" is 'Options summary theta';
+comment on column deribit.private_get_account_summary_response_fee."self_trading_extended_to_subaccounts" is 'true if self trading rejection behavior is applied to trades between subaccounts (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."interuser_transfers_enabled" is 'true when the inter-user transfers are enabled for user (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."total_initial_margin_usd" is 'Optional (only for users using cross margin). The account''s total initial margin in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summary_response_fee."estimated_liquidation_ratio" is 'Estimated Liquidation Ratio is returned only for users without portfolio margining enabled. Multiplying it by future position''s market price returns its estimated liquidation price. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."session_rpl" is 'Session realized profit and loss';
+comment on column deribit.private_get_account_summary_response_fee."fee_balance" is 'The account''s fee balance (it can be used to pay for fees)';
+comment on column deribit.private_get_account_summary_response_fee."total_maintenance_margin_usd" is 'Optional (only for users using cross margin). The account''s total maintenance margin in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summary_response_fee."options_vega" is 'Options summary vega';
+comment on column deribit.private_get_account_summary_response_fee."projected_initial_margin" is 'Projected initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
+comment on column deribit.private_get_account_summary_response_fee."self_trading_reject_mode" is 'Self trading rejection behavior - reject_taker or cancel_maker (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."system_name" is 'System generated user nickname (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."options_gamma" is 'Options summary gamma';
+comment on column deribit.private_get_account_summary_response_fee."username" is 'Account name (given by user) (available when parameter extended = true)';
+comment on column deribit.private_get_account_summary_response_fee."total_equity_usd" is 'Optional (only for users using cross margin). The account''s total equity in all cross collateral currencies, expressed in USD';
+comment on column deribit.private_get_account_summary_response_fee."delta_total" is 'The sum of position deltas';
+
+create type deribit.private_get_account_summary_response_result as (
+    "options_pl" double precision,
+    "projected_delta_total" double precision,
+    "options_theta_map" jsonb,
+    "has_non_block_chain_equity" boolean,
+    "total_margin_balance_usd" double precision,
+    "limits" jsonb,
+    "type" text,
+    "total_delta_total_usd" double precision,
+    "available_withdrawal_funds" double precision,
+    "options_session_rpl" double precision,
+    "futures_session_rpl" double precision,
+    "total_pl" double precision,
+    "spot_reserve" double precision,
+    "fees" deribit.private_get_account_summary_response_fee[]
+);
+
 comment on column deribit.private_get_account_summary_response_result."options_pl" is 'Options profit and Loss';
 comment on column deribit.private_get_account_summary_response_result."projected_delta_total" is 'The sum of position deltas without positions that will expire during closest expiration';
 comment on column deribit.private_get_account_summary_response_result."options_theta_map" is 'Map of options'' thetas per index';
@@ -126,51 +184,7 @@ comment on column deribit.private_get_account_summary_response_result."options_s
 comment on column deribit.private_get_account_summary_response_result."futures_session_rpl" is 'Futures session realized profit and Loss';
 comment on column deribit.private_get_account_summary_response_result."total_pl" is 'Profit and loss';
 comment on column deribit.private_get_account_summary_response_result."spot_reserve" is 'The account''s balance reserved in active spot orders';
-comment on column deribit.private_get_account_summary_response_result."fees" is 'User fees in case of any discounts (available when parameter extended = true and user has any discounts)';
-comment on column deribit.private_get_account_summary_response_result."additional_reserve" is 'The account''s balance reserved in other orders';
-comment on column deribit.private_get_account_summary_response_result."options_session_upl" is 'Options session unrealized profit and Loss';
-comment on column deribit.private_get_account_summary_response_result."cross_collateral_enabled" is 'When true cross collateral is enabled for user';
-comment on column deribit.private_get_account_summary_response_result."id" is 'Account id (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."options_value" is 'Options value';
-comment on column deribit.private_get_account_summary_response_result."creation_timestamp" is 'Time at which the account was created (milliseconds since the Unix epoch; available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."email" is 'User email (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."options_vega_map" is 'Map of options'' vegas per index';
-comment on column deribit.private_get_account_summary_response_result."maintenance_margin" is 'The maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."mmp_enabled" is 'Whether MMP is enabled (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."futures_session_upl" is 'Futures session unrealized profit and Loss';
-comment on column deribit.private_get_account_summary_response_result."portfolio_margining_enabled" is 'true when portfolio margining is enabled for user';
-comment on column deribit.private_get_account_summary_response_result."futures_pl" is 'Futures profit and Loss';
-comment on column deribit.private_get_account_summary_response_result."options_gamma_map" is 'Map of options'' gammas per index';
-comment on column deribit.private_get_account_summary_response_result."currency" is 'The selected currency';
-comment on column deribit.private_get_account_summary_response_result."options_delta" is 'Options summary delta';
-comment on column deribit.private_get_account_summary_response_result."initial_margin" is 'The account''s initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."projected_maintenance_margin" is 'Projected maintenance margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."available_funds" is 'The account''s available funds. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."referrer_id" is 'Optional identifier of the referrer (of the affiliation program, and available when parameter extended = true), which link was used by this account at registration. It coincides with suffix of the affiliation link path after /reg-';
-comment on column deribit.private_get_account_summary_response_result."login_enabled" is 'Whether account is loginable using email and password (available when parameter extended = true and account is a subaccount)';
-comment on column deribit.private_get_account_summary_response_result."equity" is 'The account''s current equity';
-comment on column deribit.private_get_account_summary_response_result."margin_model" is 'Name of user''s currently enabled margin model';
-comment on column deribit.private_get_account_summary_response_result."balance" is 'The account''s balance';
-comment on column deribit.private_get_account_summary_response_result."session_upl" is 'Session unrealized profit and loss';
-comment on column deribit.private_get_account_summary_response_result."margin_balance" is 'The account''s margin balance. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."security_keys_enabled" is 'Whether Security Key authentication is enabled (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."deposit_address" is 'The deposit address for the account (if available)';
-comment on column deribit.private_get_account_summary_response_result."options_theta" is 'Options summary theta';
-comment on column deribit.private_get_account_summary_response_result."self_trading_extended_to_subaccounts" is 'true if self trading rejection behavior is applied to trades between subaccounts (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."interuser_transfers_enabled" is 'true when the inter-user transfers are enabled for user (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."total_initial_margin_usd" is 'Optional (only for users using cross margin). The account''s total initial margin in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summary_response_result."estimated_liquidation_ratio" is 'Estimated Liquidation Ratio is returned only for users without portfolio margining enabled. Multiplying it by future position''s market price returns its estimated liquidation price. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."session_rpl" is 'Session realized profit and loss';
-comment on column deribit.private_get_account_summary_response_result."fee_balance" is 'The account''s fee balance (it can be used to pay for fees)';
-comment on column deribit.private_get_account_summary_response_result."total_maintenance_margin_usd" is 'Optional (only for users using cross margin). The account''s total maintenance margin in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summary_response_result."options_vega" is 'Options summary vega';
-comment on column deribit.private_get_account_summary_response_result."projected_initial_margin" is 'Projected initial margin. When cross collateral is enabled, this aggregated value is calculated by converting the sum of each cross collateral currency''s value to the given currency, using each cross collateral currency''s index.';
-comment on column deribit.private_get_account_summary_response_result."self_trading_reject_mode" is 'Self trading rejection behavior - reject_taker or cancel_maker (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."system_name" is 'System generated user nickname (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."options_gamma" is 'Options summary gamma';
-comment on column deribit.private_get_account_summary_response_result."username" is 'Account name (given by user) (available when parameter extended = true)';
-comment on column deribit.private_get_account_summary_response_result."total_equity_usd" is 'Optional (only for users using cross margin). The account''s total equity in all cross collateral currencies, expressed in USD';
-comment on column deribit.private_get_account_summary_response_result."delta_total" is 'The sum of position deltas';
+comment on column deribit.private_get_account_summary_response_result."fees" is 'List of fee objects for all currency pairs and instrument types related to the currency (available when parameter extended = true and user has any discounts)';
 
 create type deribit.private_get_account_summary_response as (
     "id" bigint,

--- a/sql/endpoints/private_get_address_book.sql
+++ b/sql/endpoints/private_get_address_book.sql
@@ -51,6 +51,7 @@ create type deribit.private_get_address_book_response_result as (
     "beneficiary_last_name" text,
     "beneficiary_vasp_did" text,
     "beneficiary_vasp_name" text,
+    "beneficiary_vasp_website" text,
     "creation_timestamp" bigint,
     "currency" text,
     "info_required" boolean,
@@ -70,6 +71,7 @@ comment on column deribit.private_get_address_book_response_result."beneficiary_
 comment on column deribit.private_get_address_book_response_result."beneficiary_last_name" is 'Last name of the beneficiary (if beneficiary is a person)';
 comment on column deribit.private_get_address_book_response_result."beneficiary_vasp_did" is 'DID of beneficiary VASP';
 comment on column deribit.private_get_address_book_response_result."beneficiary_vasp_name" is 'Name of beneficiary VASP';
+comment on column deribit.private_get_address_book_response_result."beneficiary_vasp_website" is 'Website of the beneficiary VASP';
 comment on column deribit.private_get_address_book_response_result."creation_timestamp" is 'The timestamp (milliseconds since the Unix epoch)';
 comment on column deribit.private_get_address_book_response_result."currency" is 'Currency, i.e "BTC", "ETH", "USDC"';
 comment on column deribit.private_get_address_book_response_result."info_required" is 'Signalises that addition information regarding the beneficiary of the address is required';
@@ -129,6 +131,7 @@ as $$
         (b)."beneficiary_last_name"::text,
         (b)."beneficiary_vasp_did"::text,
         (b)."beneficiary_vasp_name"::text,
+        (b)."beneficiary_vasp_website"::text,
         (b)."creation_timestamp"::bigint,
         (b)."currency"::text,
         (b)."info_required"::boolean,

--- a/sql/endpoints/private_get_open_orders.sql
+++ b/sql/endpoints/private_get_open_orders.sql
@@ -47,6 +47,7 @@ create type deribit.private_get_open_orders_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -77,6 +78,7 @@ create type deribit.private_get_open_orders_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -87,7 +89,6 @@ create type deribit.private_get_open_orders_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -100,6 +101,7 @@ comment on column deribit.private_get_open_orders_response_result."triggered" is
 comment on column deribit.private_get_open_orders_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_open_orders_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_open_orders_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_open_orders_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_open_orders_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_open_orders_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_open_orders_response_result."api" is 'true if created with API';
@@ -130,6 +132,7 @@ comment on column deribit.private_get_open_orders_response_result."price" is 'Pr
 comment on column deribit.private_get_open_orders_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_open_orders_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_open_orders_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_open_orders_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_open_orders_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_open_orders_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_open_orders_response_result."original_order_type" is 'Original order type. Optional field';
@@ -140,7 +143,6 @@ comment on column deribit.private_get_open_orders_response_result."trigger_offse
 comment on column deribit.private_get_open_orders_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_open_orders_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_open_orders_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_open_orders_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_open_orders_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_open_orders_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_open_orders_response_result."instrument_name" is 'Unique instrument identifier';
@@ -192,6 +194,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -222,6 +225,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -232,7 +236,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_open_orders_by_currency.sql
+++ b/sql/endpoints/private_get_open_orders_by_currency.sql
@@ -57,6 +57,7 @@ create type deribit.private_get_open_orders_by_currency_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -87,6 +88,7 @@ create type deribit.private_get_open_orders_by_currency_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -97,7 +99,6 @@ create type deribit.private_get_open_orders_by_currency_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -110,6 +111,7 @@ comment on column deribit.private_get_open_orders_by_currency_response_result."t
 comment on column deribit.private_get_open_orders_by_currency_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_open_orders_by_currency_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_open_orders_by_currency_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_open_orders_by_currency_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_open_orders_by_currency_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_open_orders_by_currency_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_open_orders_by_currency_response_result."api" is 'true if created with API';
@@ -140,6 +142,7 @@ comment on column deribit.private_get_open_orders_by_currency_response_result."p
 comment on column deribit.private_get_open_orders_by_currency_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_open_orders_by_currency_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_open_orders_by_currency_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_open_orders_by_currency_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_open_orders_by_currency_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."original_order_type" is 'Original order type. Optional field';
@@ -150,7 +153,6 @@ comment on column deribit.private_get_open_orders_by_currency_response_result."t
 comment on column deribit.private_get_open_orders_by_currency_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_open_orders_by_currency_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_open_orders_by_currency_response_result."instrument_name" is 'Unique instrument identifier';
@@ -204,6 +206,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -234,6 +237,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -244,7 +248,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_open_orders_by_instrument.sql
+++ b/sql/endpoints/private_get_open_orders_by_instrument.sql
@@ -39,6 +39,7 @@ create type deribit.private_get_open_orders_by_instrument_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -69,6 +70,7 @@ create type deribit.private_get_open_orders_by_instrument_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -79,7 +81,6 @@ create type deribit.private_get_open_orders_by_instrument_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -92,6 +93,7 @@ comment on column deribit.private_get_open_orders_by_instrument_response_result.
 comment on column deribit.private_get_open_orders_by_instrument_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_open_orders_by_instrument_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."api" is 'true if created with API';
@@ -122,6 +124,7 @@ comment on column deribit.private_get_open_orders_by_instrument_response_result.
 comment on column deribit.private_get_open_orders_by_instrument_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_open_orders_by_instrument_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."original_order_type" is 'Original order type. Optional field';
@@ -132,7 +135,6 @@ comment on column deribit.private_get_open_orders_by_instrument_response_result.
 comment on column deribit.private_get_open_orders_by_instrument_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_open_orders_by_instrument_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_open_orders_by_instrument_response_result."instrument_name" is 'Unique instrument identifier';
@@ -184,6 +186,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -214,6 +217,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -224,7 +228,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_open_orders_by_label.sql
+++ b/sql/endpoints/private_get_open_orders_by_label.sql
@@ -33,6 +33,7 @@ create type deribit.private_get_open_orders_by_label_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -63,6 +64,7 @@ create type deribit.private_get_open_orders_by_label_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -73,7 +75,6 @@ create type deribit.private_get_open_orders_by_label_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -86,6 +87,7 @@ comment on column deribit.private_get_open_orders_by_label_response_result."trig
 comment on column deribit.private_get_open_orders_by_label_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_open_orders_by_label_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_open_orders_by_label_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_open_orders_by_label_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_open_orders_by_label_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_open_orders_by_label_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_open_orders_by_label_response_result."api" is 'true if created with API';
@@ -116,6 +118,7 @@ comment on column deribit.private_get_open_orders_by_label_response_result."pric
 comment on column deribit.private_get_open_orders_by_label_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_open_orders_by_label_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_open_orders_by_label_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_open_orders_by_label_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_open_orders_by_label_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_open_orders_by_label_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_open_orders_by_label_response_result."original_order_type" is 'Original order type. Optional field';
@@ -126,7 +129,6 @@ comment on column deribit.private_get_open_orders_by_label_response_result."trig
 comment on column deribit.private_get_open_orders_by_label_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_open_orders_by_label_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_open_orders_by_label_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_open_orders_by_label_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_open_orders_by_label_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_open_orders_by_label_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_open_orders_by_label_response_result."instrument_name" is 'Unique instrument identifier';
@@ -178,6 +180,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -208,6 +211,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -218,7 +222,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_order_history_by_currency.sql
+++ b/sql/endpoints/private_get_order_history_by_currency.sql
@@ -57,6 +57,7 @@ create type deribit.private_get_order_history_by_currency_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -87,6 +88,7 @@ create type deribit.private_get_order_history_by_currency_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -97,7 +99,6 @@ create type deribit.private_get_order_history_by_currency_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -110,6 +111,7 @@ comment on column deribit.private_get_order_history_by_currency_response_result.
 comment on column deribit.private_get_order_history_by_currency_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_order_history_by_currency_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_order_history_by_currency_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_order_history_by_currency_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_order_history_by_currency_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_order_history_by_currency_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_order_history_by_currency_response_result."api" is 'true if created with API';
@@ -140,6 +142,7 @@ comment on column deribit.private_get_order_history_by_currency_response_result.
 comment on column deribit.private_get_order_history_by_currency_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_order_history_by_currency_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_order_history_by_currency_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_order_history_by_currency_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_order_history_by_currency_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_order_history_by_currency_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_order_history_by_currency_response_result."original_order_type" is 'Original order type. Optional field';
@@ -150,7 +153,6 @@ comment on column deribit.private_get_order_history_by_currency_response_result.
 comment on column deribit.private_get_order_history_by_currency_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_order_history_by_currency_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_order_history_by_currency_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_order_history_by_currency_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_order_history_by_currency_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_order_history_by_currency_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_order_history_by_currency_response_result."instrument_name" is 'Unique instrument identifier';
@@ -216,6 +218,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -246,6 +249,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -256,7 +260,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_order_history_by_instrument.sql
+++ b/sql/endpoints/private_get_order_history_by_instrument.sql
@@ -37,6 +37,7 @@ create type deribit.private_get_order_history_by_instrument_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -67,6 +68,7 @@ create type deribit.private_get_order_history_by_instrument_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -77,7 +79,6 @@ create type deribit.private_get_order_history_by_instrument_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -90,6 +91,7 @@ comment on column deribit.private_get_order_history_by_instrument_response_resul
 comment on column deribit.private_get_order_history_by_instrument_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_order_history_by_instrument_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_order_history_by_instrument_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_order_history_by_instrument_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_order_history_by_instrument_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_order_history_by_instrument_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_order_history_by_instrument_response_result."api" is 'true if created with API';
@@ -120,6 +122,7 @@ comment on column deribit.private_get_order_history_by_instrument_response_resul
 comment on column deribit.private_get_order_history_by_instrument_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_order_history_by_instrument_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_order_history_by_instrument_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_order_history_by_instrument_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_order_history_by_instrument_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."original_order_type" is 'Original order type. Optional field';
@@ -130,7 +133,6 @@ comment on column deribit.private_get_order_history_by_instrument_response_resul
 comment on column deribit.private_get_order_history_by_instrument_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_order_history_by_instrument_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_order_history_by_instrument_response_result."instrument_name" is 'Unique instrument identifier';
@@ -194,6 +196,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -224,6 +227,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -234,7 +238,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_order_state.sql
+++ b/sql/endpoints/private_get_order_state.sql
@@ -23,6 +23,7 @@ create type deribit.private_get_order_state_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -53,6 +54,7 @@ create type deribit.private_get_order_state_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -63,7 +65,6 @@ create type deribit.private_get_order_state_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -76,6 +77,7 @@ comment on column deribit.private_get_order_state_response_result."triggered" is
 comment on column deribit.private_get_order_state_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_order_state_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_order_state_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_order_state_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_order_state_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_order_state_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_order_state_response_result."api" is 'true if created with API';
@@ -106,6 +108,7 @@ comment on column deribit.private_get_order_state_response_result."price" is 'Pr
 comment on column deribit.private_get_order_state_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_order_state_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_order_state_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_order_state_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_order_state_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_order_state_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_order_state_response_result."original_order_type" is 'Original order type. Optional field';
@@ -116,7 +119,6 @@ comment on column deribit.private_get_order_state_response_result."trigger_offse
 comment on column deribit.private_get_order_state_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_order_state_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_order_state_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_order_state_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_order_state_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_order_state_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_order_state_response_result."instrument_name" is 'Unique instrument identifier';

--- a/sql/endpoints/private_get_order_state_by_label.sql
+++ b/sql/endpoints/private_get_order_state_by_label.sql
@@ -33,6 +33,7 @@ create type deribit.private_get_order_state_by_label_response_result as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -63,6 +64,7 @@ create type deribit.private_get_order_state_by_label_response_result as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -73,7 +75,6 @@ create type deribit.private_get_order_state_by_label_response_result as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -86,6 +87,7 @@ comment on column deribit.private_get_order_state_by_label_response_result."trig
 comment on column deribit.private_get_order_state_by_label_response_result."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_order_state_by_label_response_result."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_order_state_by_label_response_result."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_order_state_by_label_response_result."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_order_state_by_label_response_result."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_order_state_by_label_response_result."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_order_state_by_label_response_result."api" is 'true if created with API';
@@ -116,6 +118,7 @@ comment on column deribit.private_get_order_state_by_label_response_result."pric
 comment on column deribit.private_get_order_state_by_label_response_result."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_order_state_by_label_response_result."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_order_state_by_label_response_result."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_order_state_by_label_response_result."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_order_state_by_label_response_result."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_order_state_by_label_response_result."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_order_state_by_label_response_result."original_order_type" is 'Original order type. Optional field';
@@ -126,7 +129,6 @@ comment on column deribit.private_get_order_state_by_label_response_result."trig
 comment on column deribit.private_get_order_state_by_label_response_result."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_order_state_by_label_response_result."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_order_state_by_label_response_result."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_order_state_by_label_response_result."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_order_state_by_label_response_result."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_order_state_by_label_response_result."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_order_state_by_label_response_result."instrument_name" is 'Unique instrument identifier';
@@ -178,6 +180,7 @@ as $$
         (b)."mobile"::boolean,
         (b)."app_name"::text,
         (b)."implv"::double precision,
+        (b)."refresh_amount"::double precision,
         (b)."usd"::double precision,
         (b)."oto_order_ids"::text[],
         (b)."api"::boolean,
@@ -208,6 +211,7 @@ as $$
         (b)."web"::boolean,
         (b)."time_in_force"::text,
         (b)."trigger_reference_price"::double precision,
+        (b)."display_amount"::double precision,
         (b)."order_type"::text,
         (b)."is_primary_otoco"::boolean,
         (b)."original_order_type"::text,
@@ -218,7 +222,6 @@ as $$
         (b)."quote_set_id"::text,
         (b)."auto_replaced"::boolean,
         (b)."reduce_only"::boolean,
-        (b)."max_show"::double precision,
         (b)."amount"::double precision,
         (b)."risk_reducing"::boolean,
         (b)."instrument_name"::text,

--- a/sql/endpoints/private_get_subaccounts_details.sql
+++ b/sql/endpoints/private_get_subaccounts_details.sql
@@ -83,6 +83,7 @@ create type deribit.private_get_subaccounts_details_response_open_order as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -113,6 +114,7 @@ create type deribit.private_get_subaccounts_details_response_open_order as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -123,7 +125,6 @@ create type deribit.private_get_subaccounts_details_response_open_order as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -136,6 +137,7 @@ comment on column deribit.private_get_subaccounts_details_response_open_order."t
 comment on column deribit.private_get_subaccounts_details_response_open_order."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_get_subaccounts_details_response_open_order."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_get_subaccounts_details_response_open_order."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_get_subaccounts_details_response_open_order."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_get_subaccounts_details_response_open_order."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_get_subaccounts_details_response_open_order."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_get_subaccounts_details_response_open_order."api" is 'true if created with API';
@@ -166,6 +168,7 @@ comment on column deribit.private_get_subaccounts_details_response_open_order."p
 comment on column deribit.private_get_subaccounts_details_response_open_order."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_get_subaccounts_details_response_open_order."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_get_subaccounts_details_response_open_order."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_get_subaccounts_details_response_open_order."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_get_subaccounts_details_response_open_order."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."original_order_type" is 'Original order type. Optional field';
@@ -176,7 +179,6 @@ comment on column deribit.private_get_subaccounts_details_response_open_order."t
 comment on column deribit.private_get_subaccounts_details_response_open_order."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_get_subaccounts_details_response_open_order."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_get_subaccounts_details_response_open_order."instrument_name" is 'Unique instrument identifier';

--- a/sql/endpoints/private_sell.sql
+++ b/sql/endpoints/private_sell.sql
@@ -117,7 +117,7 @@ create type deribit.private_sell_request as (
     "label" text,
     "price" double precision,
     "time_in_force" deribit.private_sell_request_time_in_force,
-    "max_show" double precision,
+    "display_amount" double precision,
     "post_only" boolean,
     "reject_post_only" boolean,
     "reduce_only" boolean,
@@ -139,7 +139,7 @@ comment on column deribit.private_sell_request."type" is 'The order type, defaul
 comment on column deribit.private_sell_request."label" is 'user defined label for the order (maximum 64 characters)';
 comment on column deribit.private_sell_request."price" is 'The order price in base currency (Only for limit and stop_limit orders) When adding an order with advanced=usd, the field price should be the option price value in USD. When adding an order with advanced=implv, the field price should be a value of implied volatility in percentages. For example, price=100, means implied volatility of 100%';
 comment on column deribit.private_sell_request."time_in_force" is 'Specifies how long the order remains in effect. Default "good_til_cancelled" "good_til_cancelled" - unfilled order remains in order book until cancelled "good_til_day" - unfilled order remains in order book till the end of the trading session "fill_or_kill" - execute a transaction immediately and completely or not at all "immediate_or_cancel" - execute a transaction immediately, and any portion of the order that cannot be immediately filled is cancelled';
-comment on column deribit.private_sell_request."max_show" is 'Maximum amount within an order to be shown to other customers, 0 for invisible order';
+comment on column deribit.private_sell_request."display_amount" is 'Initial display amount for iceberg order. Has to be at least 100 times minimum amount for instrument and ratio of hidden part vs visible part has to be less than 100 as well.';
 comment on column deribit.private_sell_request."post_only" is 'If true, the order is considered post-only. If the new price would cause the order to be filled immediately (as taker), the price will be changed to be just above the spread. Only valid in combination with time_in_force="good_til_cancelled"';
 comment on column deribit.private_sell_request."reject_post_only" is 'If an order is considered post-only and this field is set to true then the order is put to the order book unmodified or the request is rejected. Only valid in combination with "post_only" set to true';
 comment on column deribit.private_sell_request."reduce_only" is 'If true, the order is considered reduce-only which is intended to only reduce a current position';
@@ -237,6 +237,7 @@ create type deribit.private_sell_response_order as (
     "mobile" boolean,
     "app_name" text,
     "implv" double precision,
+    "refresh_amount" double precision,
     "usd" double precision,
     "oto_order_ids" text[],
     "api" boolean,
@@ -267,6 +268,7 @@ create type deribit.private_sell_response_order as (
     "web" boolean,
     "time_in_force" text,
     "trigger_reference_price" double precision,
+    "display_amount" double precision,
     "order_type" text,
     "is_primary_otoco" boolean,
     "original_order_type" text,
@@ -277,7 +279,6 @@ create type deribit.private_sell_response_order as (
     "quote_set_id" text,
     "auto_replaced" boolean,
     "reduce_only" boolean,
-    "max_show" double precision,
     "amount" double precision,
     "risk_reducing" boolean,
     "instrument_name" text,
@@ -290,6 +291,7 @@ comment on column deribit.private_sell_response_order."triggered" is 'Whether th
 comment on column deribit.private_sell_response_order."mobile" is 'optional field with value true added only when created with Mobile Application';
 comment on column deribit.private_sell_response_order."app_name" is 'The name of the application that placed the order on behalf of the user (optional).';
 comment on column deribit.private_sell_response_order."implv" is 'Implied volatility in percent. (Only if advanced="implv")';
+comment on column deribit.private_sell_response_order."refresh_amount" is 'The initial display amount of iceberg order. Iceberg order display amount will be refreshed to that value after match consuming actual display amount. Absent for other types of orders';
 comment on column deribit.private_sell_response_order."usd" is 'Option price in USD (Only if advanced="usd")';
 comment on column deribit.private_sell_response_order."oto_order_ids" is 'The Ids of the orders that will be triggered if the order is filled';
 comment on column deribit.private_sell_response_order."api" is 'true if created with API';
@@ -320,6 +322,7 @@ comment on column deribit.private_sell_response_order."price" is 'Price in base 
 comment on column deribit.private_sell_response_order."web" is 'true if created via Deribit frontend (optional)';
 comment on column deribit.private_sell_response_order."time_in_force" is 'Order time in force: "good_til_cancelled", "good_til_day", "fill_or_kill" or "immediate_or_cancel"';
 comment on column deribit.private_sell_response_order."trigger_reference_price" is 'The price of the given trigger at the time when the order was placed (Only for trailing trigger orders)';
+comment on column deribit.private_sell_response_order."display_amount" is 'The actual display amount of iceberg order. Absent for other types of orders.';
 comment on column deribit.private_sell_response_order."order_type" is 'Order type: "limit", "market", "stop_limit", "stop_market"';
 comment on column deribit.private_sell_response_order."is_primary_otoco" is 'true if the order is an order that can trigger an OCO pair, otherwise not present.';
 comment on column deribit.private_sell_response_order."original_order_type" is 'Original order type. Optional field';
@@ -330,7 +333,6 @@ comment on column deribit.private_sell_response_order."trigger_offset" is 'The m
 comment on column deribit.private_sell_response_order."quote_set_id" is 'Identifier of the QuoteSet supplied in the private/mass_quote request.';
 comment on column deribit.private_sell_response_order."auto_replaced" is 'Options, advanced orders only - true if last modification of the order was performed by the pricing engine, otherwise false.';
 comment on column deribit.private_sell_response_order."reduce_only" is 'Optional (not added for spot). ''true for reduce-only orders only''';
-comment on column deribit.private_sell_response_order."max_show" is 'Maximum amount within an order to be shown to other traders, 0 for invisible order.';
 comment on column deribit.private_sell_response_order."amount" is 'It represents the requested order size. For perpetual and inverse futures the amount is in USD units. For options and linear futures and it is the underlying base currency coin.';
 comment on column deribit.private_sell_response_order."risk_reducing" is 'true if the order is marked by the platform as a risk reducing order (can apply only to orders placed by PM users), otherwise false.';
 comment on column deribit.private_sell_response_order."instrument_name" is 'Unique instrument identifier';
@@ -359,7 +361,7 @@ create function deribit.private_sell(
     "label" text default null,
     "price" double precision default null,
     "time_in_force" deribit.private_sell_request_time_in_force default null,
-    "max_show" double precision default null,
+    "display_amount" double precision default null,
     "post_only" boolean default null,
     "reject_post_only" boolean default null,
     "reduce_only" boolean default null,
@@ -386,7 +388,7 @@ as $$
             "label",
             "price",
             "time_in_force",
-            "max_show",
+            "display_amount",
             "post_only",
             "reject_post_only",
             "reduce_only",

--- a/sql/endpoints/private_update_in_address_book.sql
+++ b/sql/endpoints/private_update_in_address_book.sql
@@ -40,6 +40,7 @@ create type deribit.private_update_in_address_book_request as (
     "address" text,
     "beneficiary_vasp_name" text,
     "beneficiary_vasp_did" text,
+    "beneficiary_vasp_website" text,
     "beneficiary_first_name" text,
     "beneficiary_last_name" text,
     "beneficiary_company_name" text,
@@ -54,6 +55,7 @@ comment on column deribit.private_update_in_address_book_request."type" is '(Req
 comment on column deribit.private_update_in_address_book_request."address" is '(Required) Address in currency format, it must be in address book';
 comment on column deribit.private_update_in_address_book_request."beneficiary_vasp_name" is '(Required) Name of beneficiary VASP';
 comment on column deribit.private_update_in_address_book_request."beneficiary_vasp_did" is '(Required) DID of beneficiary VASP';
+comment on column deribit.private_update_in_address_book_request."beneficiary_vasp_website" is 'Website of the beneficiary VASP. Required if the address book entry is associated with a VASP that is not included in the list of known VASPs';
 comment on column deribit.private_update_in_address_book_request."beneficiary_first_name" is 'First name of beneficiary (if beneficiary is a person)';
 comment on column deribit.private_update_in_address_book_request."beneficiary_last_name" is 'First name of beneficiary (if beneficiary is a person)';
 comment on column deribit.private_update_in_address_book_request."beneficiary_company_name" is 'Beneficiary company name (if beneficiary is a company)';
@@ -82,6 +84,7 @@ create function deribit.private_update_in_address_book(
     "agreed" boolean,
     "personal" boolean,
     "label" text,
+    "beneficiary_vasp_website" text default null,
     "beneficiary_first_name" text default null,
     "beneficiary_last_name" text default null,
     "beneficiary_company_name" text default null
@@ -97,6 +100,7 @@ as $$
             "address",
             "beneficiary_vasp_name",
             "beneficiary_vasp_did",
+            "beneficiary_vasp_website",
             "beneficiary_first_name",
             "beneficiary_last_name",
             "beneficiary_company_name",

--- a/sql/endpoints/private_verify_block_trade.sql
+++ b/sql/endpoints/private_verify_block_trade.sql
@@ -49,7 +49,7 @@ create type deribit.private_verify_block_trade_response_result as (
     "signature" text
 );
 
-comment on column deribit.private_verify_block_trade_response_result."signature" is 'Signature of block trade It is valid only for 5 minutes “around” given timestamp';
+comment on column deribit.private_verify_block_trade_response_result."signature" is 'Signature of block trade It is valid only for 5 minutes around given timestamp';
 
 create type deribit.private_verify_block_trade_response as (
     "id" bigint,

--- a/sql/endpoints/public_get_book_summary_by_currency.sql
+++ b/sql/endpoints/public_get_book_summary_by_currency.sql
@@ -154,4 +154,5 @@ as $$
     
 $$;
 
-comment on function deribit.public_get_book_summary_by_currency is 'Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).';
+comment on function deribit.public_get_book_summary_by_currency is 'Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
+Note - For real-time updates, we recommend using the WebSocket subscription to ticker.{instrument_name}.{interval} instead of polling this endpoint.';

--- a/sql/endpoints/public_get_instruments.sql
+++ b/sql/endpoints/public_get_instruments.sql
@@ -181,4 +181,5 @@ as $$
     
 $$;
 
-comment on function deribit.public_get_instruments is 'Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.';
+comment on function deribit.public_get_instruments is 'Retrieves available trading instruments. This method can be used to see which instruments are available for trading, or which instruments have recently expired.
+Note - This endpoint has distinct API rate limiting requirements: 1 request per 10 seconds, with a burst of 5. To avoid rate limits, we recommend using either the REST requests for server-cached data or the WebSocket subscription to instrument_state.{kind}.{currency} for real-time updates. For more information, see Rate Limits.';


### PR DESCRIPTION
This pull request introduces updates to several SQL types and functions to enhance functionality and improve clarity in the `private_add_to_address_book`, `private_buy`, `private_cancel`, and `private_close_position` endpoints. Key changes include the addition of new fields, updates to comments for better documentation, and the replacement of the `max_show` field with `display_amount` in relevant endpoints.

### Updates to `private_add_to_address_book`:

* Added `beneficiary_vasp_website` and `extra_currencies` fields to the `private_add_to_address_book_request` and `private_add_to_address_book_response_result` types. These fields allow specifying a beneficiary VASP's website and a list of extra currencies for ERC20 addresses. [[1]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R44-R51) [[2]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R78)
* Updated comments to document the new fields, including usage details for `beneficiary_vasp_website` and `extra_currencies`. [[1]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R60-R67) [[2]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R98)
* Modified the `private_add_to_address_book` function to include the new fields as optional parameters. [[1]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R129-R133) [[2]](diffhunk://#diff-1053225bb419c829568a81ce52921af81d20711b24c3a210baf3f2a157ca4293R147-R154)

### Updates to `private_buy`:

* Replaced the `max_show` field with `display_amount` in the `private_buy_request` and `private_buy_response_order` types. This change reflects a shift to support iceberg order display amounts. [[1]](diffhunk://#diff-538f491692c8c327b7d99066cdc06e11134dcf22b7ff57bcb8183784fcb23251L120-R120) [[2]](diffhunk://#diff-538f491692c8c327b7d99066cdc06e11134dcf22b7ff57bcb8183784fcb23251R271)
* Added `refresh_amount` to the `private_buy_response_order` type to track the initial display amount for iceberg orders.
* Updated comments to reflect the changes, providing detailed explanations of the new fields. [[1]](diffhunk://#diff-538f491692c8c327b7d99066cdc06e11134dcf22b7ff57bcb8183784fcb23251L142-R142) [[2]](diffhunk://#diff-538f491692c8c327b7d99066cdc06e11134dcf22b7ff57bcb8183784fcb23251R294)

### Updates to `private_cancel` and `private_close_position`:

* Introduced `refresh_amount` and `display_amount` fields to the `private_cancel_response_result` and `private_close_position_response_order` types, aligning them with the updates made to `private_buy`. [[1]](diffhunk://#diff-d8b06ce92e333b323a3d66a90a478c152204a0e85952d476a90bdbcd28497214R26) [[2]](diffhunk://#diff-94b1bc06c7cefdd1f5fb513e0909c33b749dc88fe0145445b26ffb1f4d6d176eR113)
* Removed the `max_show` field from these types for consistency. [[1]](diffhunk://#diff-d8b06ce92e333b323a3d66a90a478c152204a0e85952d476a90bdbcd28497214L66) [[2]](diffhunk://#diff-94b1bc06c7cefdd1f5fb513e0909c33b749dc88fe0145445b26ffb1f4d6d176eR144)
* Updated comments to document the new fields and their purposes. [[1]](diffhunk://#diff-d8b06ce92e333b323a3d66a90a478c152204a0e85952d476a90bdbcd28497214R80) [[2]](diffhunk://#diff-94b1bc06c7cefdd1f5fb513e0909c33b749dc88fe0145445b26ffb1f4d6d176eR144)